### PR TITLE
Fix Select menu overflow in Modal component

### DIFF
--- a/src/components/form/select/AsyncCreatableSelect.tsx
+++ b/src/components/form/select/AsyncCreatableSelect.tsx
@@ -48,6 +48,7 @@ export function AsyncCreatableSelect<
         aria-invalid={inputProps['aria-invalid']}
         components={{ MultiValue, Control }}
         maxMenuHeight={210}
+        menuPortalTarget={document?.body}
         {...props}
       />
     </Box>

--- a/src/components/form/select/AsyncSelect.tsx
+++ b/src/components/form/select/AsyncSelect.tsx
@@ -42,6 +42,7 @@ export function AsyncSelect<
         aria-invalid={inputProps['aria-invalid']}
         components={{ MultiValue, Control }}
         maxMenuHeight={210}
+        menuPortalTarget={document?.body}
         {...props}
       />
     </Box>

--- a/src/components/form/select/CreatableSelect.tsx
+++ b/src/components/form/select/CreatableSelect.tsx
@@ -36,6 +36,7 @@ export function CreatableSelect<
         aria-invalid={inputProps['aria-invalid']}
         components={{ MultiValue, Control }}
         maxMenuHeight={210}
+        menuPortalTarget={document?.body}
         {...props}
       />
     </Box>

--- a/src/components/form/select/Select.tsx
+++ b/src/components/form/select/Select.tsx
@@ -94,6 +94,7 @@ export function Select<
         aria-invalid={inputProps['aria-invalid']}
         components={{ MultiValue, Control }}
         maxMenuHeight={210}
+        menuPortalTarget={document?.body}
         {...props}
       />
     </Box>

--- a/src/components/form/style.ts
+++ b/src/components/form/style.ts
@@ -5,7 +5,7 @@ import { variant } from 'styled-system'
 
 import { CapUIFontFamily, CapUILineHeight } from '../../styles'
 import colors from '../../styles/modules/colors'
-import { SPACING } from '../../styles/theme'
+import { SPACING, ZINDEX } from '../../styles/theme'
 import { FONT_FAMILIES, LINE_HEIGHTS } from '../../styles/theme/typography'
 import { Box } from '../box'
 import { CapInputSize } from './enums'
@@ -170,6 +170,10 @@ export function reactSelectStyle<
       margin: 0,
       color: colors.gray[isDisabled ? '500' : '700'],
       display: isSearch ? 'none' : 'flex',
+    }),
+    menuPortal: (base: CSSObjectWithLabel) => ({
+      ...base,
+      zIndex: ZINDEX.select,
     }),
   }
 }

--- a/src/components/modal/Modal.stories.tsx
+++ b/src/components/modal/Modal.stories.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 
 import { Button } from '../button'
 import { FormControl, FormErrorMessage, FormLabel, Input } from '../form'
+import Select from '../form/select/Select'
 import { CapUIIcon, CapUIIconSize, Icon } from '../icon'
 import { Flex } from '../layout'
 import { Tooltip } from '../tooltip/Tooltip'
@@ -433,6 +434,51 @@ export const DoNotHideOnEsc: Story<ModalProps> = args => (
 )
 DoNotHideOnEsc.storyName = 'do not hide on ESC'
 DoNotHideOnEsc.args = { hideOnEsc: false }
+
+const options = [
+  { value: 'mail1', label: 'mail1@cap-collectif.com' },
+  { value: 'mail2', label: 'mail2@cap-collectif.com' },
+  { value: 'mail3', label: 'mail3@cap-collectif.com' },
+  { value: 'mail4', label: 'mail4@cap-collectif.com' },
+  { value: 'mail5', label: 'mail5@cap-collectif.com' },
+  { value: 'mail6', label: 'mail6@cap-collectif.com' },
+]
+
+export const WithSelectOverflow: Story<ModalProps> = args => (
+  <>
+    <Modal {...args}>
+      {({ hide }) => (
+        <>
+          <Modal.Header>
+            <Heading>Title</Heading>
+          </Modal.Header>
+          <Modal.Body>
+            <Select options={options} />
+          </Modal.Body>
+          <Modal.Footer>
+            <Button
+              variant="secondary"
+              variantColor="primary"
+              variantSize="big"
+              onClick={hide}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              variantColor="primary"
+              variantSize="big"
+              onClick={hide}
+            >
+              Validate
+            </Button>
+          </Modal.Footer>
+        </>
+      )}
+    </Modal>
+  </>
+)
+WithSelectOverflow.storyName = 'With Select Overflow'
 
 export const ControlledModal: Story<ModalProps> = args => {
   const [show, setShow] = React.useState(false)

--- a/src/styles/theme/index.ts
+++ b/src/styles/theme/index.ts
@@ -148,6 +148,7 @@ export const ZINDEX = {
   dropdown: 1000,
   overlay: 1300,
   modal: 1400,
+  select: 1500,
   popover: 1500,
   tooltip: 1700,
   toast: 1800,


### PR DESCRIPTION
#### :tophat: What? Why?
Actuellement sur les modales + select : 

<img width="884" alt="Capture d’écran 2022-01-11 à 09 37 49" src="https://user-images.githubusercontent.com/21263655/148908843-208f2e65-8606-456e-bb08-61549126c08d.png">

On veut : 

<img width="452" alt="Capture d’écran 2022-01-11 à 09 37 39" src="https://user-images.githubusercontent.com/21263655/148908874-919a721f-b15f-4c27-a0dc-699ac09f1618.png">

La solution pour ne pas toucher aux réglages de la modale et conserver un scroll : [on envoi le menu dans un portal avec un zindex supérieur à la modale](https://stackoverflow.com/questions/55830799/how-to-change-zindex-in-react-select-drowpdown).

Ca devrait faire l'affaire, j'ai rajouté une story pour ce cas, comme ça en cas de changement on sera notifié 

#### :pushpin: Related Issues
<!-- What existing **issue(s)** does the pull request solve? -->

#### :clipboard: Technical Specification
<!-- Describe how you plan to solve the problem
- [x] Subtask 1
- [ ] Subtask 2
-->

#### :art: Chromatic links
<!--
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=<PR number>)
[Storybook](https://<branch>--60ca00d41db7ba003be931d8.chromatic.com) 
-->

#### :camera_flash: Screenshots
<!-- Screenshots if appropriate -->