### PR TITLE
InfiniteScroll on Array : adds ref possibility

### DIFF
--- a/src/components/table/tbody/Tbody.tsx
+++ b/src/components/table/tbody/Tbody.tsx
@@ -77,7 +77,7 @@ const Tbody: React.FC<TbodyProps> = ({
       getScrollParent={
         scrollParentRef?.current ? () => scrollParentRef?.current : undefined
       }
-      useWindow={!scrollParentRef?.current}
+      useWindow={!Boolean(scrollParentRef?.current)}
     >
       {children}
     </InfiniteScroll>


### PR DESCRIPTION
#### :tophat: What? Why?
Dans l'infiniteScroll du tableau, on permet de passer une ref sur laquelle se baser. Ca permet plus de souplesse, actuellement avec un layout un peu complexe comme le notre ca détectait pas le bottom car le compo était en listen sur le scroll de la window

À noter que react-infinite-scroller se base sur l'ancien système de refs, d'ou le current pour l'abstraire et pouvoir passer des nouvelles refs à notre tableau 😃 

#### :pushpin: Related Issues
<!-- What existing **issue(s)** does the pull request solve? -->

#### :clipboard: Technical Specification
<!-- Describe how you plan to solve the problem
- [x] Subtask 1
- [ ] Subtask 2
-->

#### :art: Chromatic links
<!--
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=<PR number>)
[Storybook](https://<branch>--60ca00d41db7ba003be931d8.chromatic.com) 
-->

#### :camera_flash: Screenshots
<!-- Screenshots if appropriate -->