### PR TITLE
fix tooltip falsy value

### DIFF
--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -61,6 +61,8 @@ export const Tooltip: React.FC<TooltipProps> = ({
     }, 400)
   }
 
+  const isValidLabel = typeof label === 'number' || !!label;
+
   return (
     <>
       <TooltipReference
@@ -72,34 +74,38 @@ export const Tooltip: React.FC<TooltipProps> = ({
         {referenceProps => React.cloneElement(children, referenceProps)}
       </TooltipReference>
 
-      <ReakitTooltip {...tooltip} className="cap-tooltip" baseId={baseId}>
-        <AnimatePresence>
-          {tooltip.visible && (
-            <ContainerAnimate
-              p={1}
-              bg="gray.900"
-              color="white"
-              borderRadius="tooltip"
-              maxWidth="270px"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={LAYOUT_TRANSITION_SPRING}
-              className={cn('cap-tooltip', className)}
-              zIndex="tooltip"
-              {...props}
-            >
-              <Arrow {...tooltip} />
-              {typeof label === 'string' && (
-                <Text textAlign="center" lineHeight="sm" fontSize={1}>
-                  {label}
-                </Text>
+      {
+        isValidLabel && (
+          <ReakitTooltip {...tooltip} className="cap-tooltip" baseId={baseId}>
+            <AnimatePresence>
+              {tooltip.visible && (
+                <ContainerAnimate
+                  p={1}
+                  bg="gray.900"
+                  color="white"
+                  borderRadius="tooltip"
+                  maxWidth="270px"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={LAYOUT_TRANSITION_SPRING}
+                  className={cn('cap-tooltip', className)}
+                  zIndex="tooltip"
+                  {...props}
+                >
+                  <Arrow {...tooltip} />
+                  {(typeof label === 'string') && (
+                    <Text textAlign="center" lineHeight="sm" fontSize={1}>
+                      {label}
+                    </Text>
+                  )}
+                  {typeof label !== 'string' && label}
+                </ContainerAnimate>
               )}
-              {typeof label !== 'string' && label}
-            </ContainerAnimate>
-          )}
-        </AnimatePresence>
-      </ReakitTooltip>
+            </AnimatePresence>
+          </ReakitTooltip>
+        )
+      }
     </>
   )
 }


### PR DESCRIPTION
#### :tophat: What? Why?
<!-- Describe your changes -->
fix du bug sur le contenu de la tooltip quand celui ci est falsy
ce check permet de filter les valeurs qui sont `null`  `undefined` ou `''` tout en acceptant les `0`

#### :pushpin: Related Issues
<!-- What existing **issue(s)** does the pull request solve? -->

#### :clipboard: Technical Specification
<!-- Describe how you plan to solve the problem
- [x] Subtask 1
- [ ] Subtask 2
-->

#### :art: Chromatic links
<!--
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=<PR number>)
[Storybook](https://<branch>--60ca00d41db7ba003be931d8.chromatic.com) 
-->

#### :camera_flash: Screenshots
<!-- Screenshots if appropriate -->