### PR TITLE
Fix non scrollable modal on mobile safari

### DIFF
--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -118,15 +118,16 @@ export const Modal: React.FC<ModalProps> & SubComponents = ({
   baseId,
   ...props
 }: ModalProps) => {
+  const isMobile = useIsMobile()
   const dialog = useDialogState({
     animated: TRANSITION_DURATION * 1000,
     visible: show,
     baseId,
+    modal: !isMobile,
   })
 
   const containerRef = React.useRef<HTMLElement>(null)
   const firstMount = React.useRef(true)
-  const isMobile = useIsMobile()
   const context = React.useMemo(
     () => ({
       hide: dialog.hide,

--- a/src/components/modal/footer/ModalFooter.tsx
+++ b/src/components/modal/footer/ModalFooter.tsx
@@ -53,6 +53,7 @@ export const ModalFooter: React.FC<ModalFooterProps> = ({
         isMobile && fullSizeOnMobile ? CapUIRadius.Popover : 'unset'
       }
       spacing={6}
+      flexShrink={0}
       className={cn('cap-modal__footer', className)}
       {...rest}
     >

--- a/src/components/modal/header/ModalHeader.tsx
+++ b/src/components/modal/header/ModalHeader.tsx
@@ -42,6 +42,7 @@ const ModalHeader: React.FC<ModalHeaderProps> & SubComponents = ({
       boxShadow={isMobile && fullSizeOnMobile ? 'small' : 'none'}
       borderColor={isMobile ? 'transparent' : 'gray.200'}
       className={cn('cap-modal__header', className)}
+      flexShrink={0}
       borderBottomLeftRadius={
         isMobile && fullSizeOnMobile ? CapUIRadius.Popover : 'unset'
       }


### PR DESCRIPTION
#### :tophat: What? Why?
<!-- Describe your changes -->
Sur iOS Safari, on pouvait pas scroll dans la modale. 

Pour régler ça je désactive l'état `modal` du dialogstate sur mobile. Ca change pas grand chose, si ce n'est que la modale ne s'ouvre plus dans un portal.

Au passage on empêche le header et le footer de ressembler à rien

#### :pushpin: Related Issues
<!-- What existing **issue(s)** does the pull request solve? -->

#### :clipboard: Technical Specification
<!-- Describe how you plan to solve the problem
- [x] Subtask 1
- [ ] Subtask 2
-->

#### :art: Chromatic links
<!--
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=<PR number>)
[Storybook](https://<branch>--60ca00d41db7ba003be931d8.chromatic.com) 
-->

#### :camera_flash: Screenshots
<!-- Screenshots if appropriate -->