### PR TITLE
0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,17 @@ To better understand the changelog, here are some legends we use:
 - 🛠 Refactor
 - 💄 Style
 
+## 0.9.3
+
+`2022-02-15`
+
+- 🐛 Export uploader type `FileInfo` [#206](https://github.com/cap-collectif/ui/pull/206)
+- 🐛 Ajout de la prop `type` button par défaut pour le `MenuItem` [#206](https://github.com/cap-collectif/ui/pull/206)
+- 🐛 Fix PhoneNumber Export [#205](https://github.com/cap-collectif/ui/pull/205)
+- 
 ## 0.9.2
+
+`2022-02-10`
 
 - 🆕 Add `PhoneNumber` component [#199](https://github.com/cap-collectif/ui/pull/199)
 - 🆕 Add `MultiStepModal` component [#200](https://github.com/cap-collectif/ui/pull/200)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.9.2",
+  "version": "0.9.3",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## 0.9.3


- 🐛 Export uploader type `FileInfo` [#206](https://github.com/cap-collectif/ui/pull/206)
- 🐛 Ajout de la prop `type` button par défaut pour le `MenuItem` [#206](https://github.com/cap-collectif/ui/pull/206)
- 🐛 Fix PhoneNumber Export [#205](https://github.com/cap-collectif/ui/pull/205)


