### PR TITLE
[10] Improve DateRange props

### DIFF
--- a/src/components/form/dateRange/DateRange.stories.tsx
+++ b/src/components/form/dateRange/DateRange.stories.tsx
@@ -31,8 +31,6 @@ const meta: Meta = {
   args: {
     startDateId: 'startDateId',
     endDateId: 'endDateId',
-    className: 'cap-dateRange',
-    errorMessage: 'Error info.',
     isRequired: false,
     isInvalid: false,
     isDisabled: false,
@@ -83,7 +81,7 @@ Disabled.args = {
   isDisabled: true,
 }
 
-export const WithAnErrorMessage: Story<DateRangeProps> = ({
+export const WithError: Story<DateRangeProps> = ({
   errorMessage,
   onChange: storybookOnChange,
   value: storybookValue,
@@ -114,8 +112,9 @@ export const WithAnErrorMessage: Story<DateRangeProps> = ({
   )
 }
 
-WithAnErrorMessage.args = {
+WithError.args = {
   isInvalid: true,
+  errorMessage: 'Error info.',
 }
 
 export const WithLabel: Story<DateRangeProps> = ({

--- a/src/components/form/dateRange/DateRange.tsx
+++ b/src/components/form/dateRange/DateRange.tsx
@@ -1,7 +1,7 @@
 import cn from 'classnames'
-import { Moment } from 'moment'
+import type { Moment } from 'moment'
 import React, { FC } from 'react'
-import { DateRangePickerInputShape, FocusedInputShape } from 'react-dates'
+import type { DateRangePickerShape, FocusedInputShape } from 'react-dates'
 import 'react-dates/initialize'
 import DateRangePicker from 'react-dates/lib/components/DateRangePicker'
 import { useHotkeys } from 'react-hotkeys-hook'
@@ -21,30 +21,33 @@ export type DateRangeValueType = {
 }
 
 export interface DateRangeProps
-  extends Omit<BoxPropsOf<'input'>, 'onChange' | 'value' | 'disabled'>,
-    DateRangePickerInputShape {
+  extends Omit<BoxPropsOf<'input'>, 'onChange' | 'value' | 'disabled'> {
   readonly value: DateRangeValueType
   readonly onChange: (value: DateRangeValueType) => void
-  readonly startDatePlaceholderText?: string
-  readonly endDatePlaceholderText?: string
-  readonly startDateId?: string
-  readonly endDateId?: string
+  readonly displayFormat: DateRangePickerShape['displayFormat']
   readonly className?: string
   readonly variantSize?: CapInputSize
   readonly errorMessage?: string
   readonly isDisabled?: boolean
   readonly isInvalid?: boolean
   readonly isRequired?: boolean
-  readonly displayFormat: string | (() => string) | undefined
+  readonly startDatePlaceholderText?: DateRangePickerShape['startDatePlaceholderText']
+  readonly endDatePlaceholderText?: DateRangePickerShape['endDatePlaceholderText']
+  readonly startDateId?: DateRangePickerShape['startDateId']
+  readonly endDateId?: DateRangePickerShape['endDateId']
+  readonly disabled?: DateRangePickerShape['disabled']
+  readonly keepOpenOnDateSelect?: DateRangePickerShape['keepOpenOnDateSelect']
+  readonly isOutsideRange?: DateRangePickerShape['isOutsideRange']
+  readonly minDate?: DateRangePickerShape['minDate']
+  readonly maxDate?: DateRangePickerShape['maxDate']
 }
 
-const CustomDayContent = (day: Moment): React.ReactNode => {
-  return (
-    <Flex justify="center" align="center" borderRadius={CapUIRadius.Poppin}>
-      {day.format('D')}
-    </Flex>
-  )
-}
+const CustomDayContent = (day: Moment): React.ReactNode => (
+  <Flex justify="center" align="center" borderRadius={CapUIRadius.Poppin}>
+    {day.format('D')}
+  </Flex>
+)
+
 const DateRange: FC<DateRangeProps> = ({
   startDatePlaceholderText = 'jj/mm/aaaa',
   endDatePlaceholderText = 'jj/mm/aaaa',
@@ -54,6 +57,10 @@ const DateRange: FC<DateRangeProps> = ({
   endDateId = 'cap-dateRange-endDate',
   displayFormat,
   className,
+  keepOpenOnDateSelect = true,
+  isOutsideRange,
+  minDate,
+  maxDate,
   ...props
 }) => {
   const [
@@ -68,6 +75,7 @@ const DateRange: FC<DateRangeProps> = ({
   // The library doesn't handle closing the calendar after Tabbing out of the input
   // https://github.com/airbnb/react-dates/issues/1809
   useHotkeys('esc', () => setFocusedInput(null))
+
   return (
     <DateRangeBox
       className={cn('cap-dateRange', className)}
@@ -92,7 +100,10 @@ const DateRange: FC<DateRangeProps> = ({
         verticalSpacing={8}
         horizontalMargin={0}
         daySize={32}
-        keepOpenOnDateSelect
+        keepOpenOnDateSelect={keepOpenOnDateSelect}
+        isOutsideRange={isOutsideRange}
+        minDate={minDate}
+        maxDate={maxDate}
         navPrev={<NavPrev />}
         navNext={<NavNext />}
         customInputIcon={


### PR DESCRIPTION
#### :tophat: What? Why?
Ajout de 3 nouvelles props disponibles pour le composants : 
- `isOutsideRange`
- `minDate`
- `maxDate`
 
(Bonus : Correction du typage des props) 

#### :pushpin: Related Issues
#10

#### :art: Chromatic links
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=223)
[Storybook](https://10-improve-daterange--60ca00d41db7ba003be931d8.chromatic.com) 