### PR TITLE
Fix `Popover`outline when `:focus-visible`

### DIFF
--- a/src/components/popover/Popover.tsx
+++ b/src/components/popover/Popover.tsx
@@ -59,6 +59,12 @@ const Arrow = styled(PopoverArrow)`
   }
 `
 
+const StyledReakitPopover = styled(ReakitPopover)`
+  &:focus-visible {
+    outline: none;
+  }
+`
+
 const getGutter = (placement: PopoverProps['placement']): number => {
   switch (placement) {
     case 'left-start':
@@ -116,7 +122,7 @@ export const Popover: React.FC<PopoverProps> & SubComponents = ({
       >
         {disclosureProps => React.cloneElement(disclosure, disclosureProps)}
       </PopoverDisclosure>
-      <ReakitPopover tabIndex={0} {...popover}>
+      <StyledReakitPopover tabIndex={0} {...popover}>
         <AnimatePresence>
           {popover.visible && (
             <ContainerAnimate
@@ -147,7 +153,7 @@ export const Popover: React.FC<PopoverProps> & SubComponents = ({
             </ContainerAnimate>
           )}
         </AnimatePresence>
-      </ReakitPopover>
+      </StyledReakitPopover>
     </PopoverContext.Provider>
   )
 }


### PR DESCRIPTION
#### :tophat: What? Why?
<!-- Describe your changes -->
Just a quick fix for the state of `:focus-visible`


#### :art: Chromatic links
<!--
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=<PR number>)
[Storybook](https://<branch>--60ca00d41db7ba003be931d8.chromatic.com) 
-->

[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=228)
[Storybook](https://popover-outline-fix--60ca00d41db7ba003be931d8.chromatic.com) 