### PR TITLE
v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ To better understand the changelog, here are some legends we use:
 - 🛠 Refactor
 - 💄 Style
 
+## 1.0.3
+
+`2022-03-14`
+
+- 🐛 Adds the react-select portal zIndex on the enum  [#233](https://github.com/cap-collectif/ui/pull/233)
+- 🐛 Allow to manually set the modal overlay zIndex [#232](https://github.com/cap-collectif/ui/pull/232)
+
 ## 1.0.2
 
 `2022-03-08`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## 1.0.3

`2022-03-14`

- 🐛 Adds the react-select portal zIndex on the enum  [#233](https://github.com/cap-collectif/ui/pull/233)
- 🐛 Allow to manually set the modal overlay zIndex [#232](https://github.com/cap-collectif/ui/pull/232)