### PR TITLE
[176] Fix modal overlay

### DIFF
--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -203,7 +203,7 @@ export const Modal: React.FC<ModalProps> & SubComponents = ({
               <ModalInner
                 direction="column"
                 justify="space-between"
-                overflow={scrollBehavior === 'inside' ? 'overlay' : undefined}
+                overflow={scrollBehavior === 'inside' ? 'auto' : undefined}
                 initial={{ opacity: 0, y: isMobile ? 20 : -20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{


### PR DESCRIPTION
#### :tophat: What? Why?
Correction de la propriété `overflow` sur l'overlay du composant `Modal` 
`overflow: overlay` est deprecated et ne fonctionne pas sur firefox, on le remplace donc par `auto` qui se rapproche le plus du comportement d'`overlay`

https://developer.mozilla.org/fr/docs/Web/CSS/overflow

#### :pushpin: Related Issues
#176

#### :art: Chromatic links
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=236)
[Storybook](https://176-fix-overflow-overlay--60ca00d41db7ba003be931d8.chromatic.com) 
