### PR TITLE
Fix `MultiStepModal` info prop

### DIFF
--- a/src/components/multiStepModal/MultiStepModal.stories.tsx
+++ b/src/components/multiStepModal/MultiStepModal.stories.tsx
@@ -99,10 +99,6 @@ export const Default: Story<MultiStepModalProps> = () => (
             id="one"
             label="Jaime les pommes"
             validationLabel="Voir les poires"
-            info={{
-              url: '#',
-              label: 'Jaime les pommes',
-            }}
           />
           <ModalTwo
             id="two"
@@ -113,14 +109,7 @@ export const Default: Story<MultiStepModalProps> = () => (
               label: 'Jaime les pommes',
             }}
           />
-          <ModalThree
-            id="three"
-            validationLabel="Fermer"
-            info={{
-              url: '#',
-              label: 'Jaime les pommes',
-            }}
-          />
+          <ModalThree id="three" validationLabel="Fermer" />
         </MultiStepModal.Body>
 
         <MultiStepModal.Footer>

--- a/src/components/multiStepModal/body/MultiStepModal.Body.tsx
+++ b/src/components/multiStepModal/body/MultiStepModal.Body.tsx
@@ -43,7 +43,7 @@ const MultiStepModalBody = ({ children, ...rest }: Props) => {
             id: id,
             label: label,
             validationLabel: validationLabel,
-            info: {
+            info: info && {
               url: info.url,
               label: info.label,
             },


### PR DESCRIPTION
#### :tophat: What? Why?
<!-- Describe your changes -->

In this repo i change the prop `info` to optional like what we have for `Modal`

#### :pushpin: Related Issues
<!-- What existing **issue(s)** does the pull request solve? -->

NA

#### :art: Chromatic links
<!--
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=<PR number>)
[Storybook](https://<branch>--60ca00d41db7ba003be931d8.chromatic.com) 
-->

[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=239)
[Storybook](https://fix-multistepmodal--60ca00d41db7ba003be931d8.chromatic.com) 