### PR TITLE
`MultiStepModal` pass context actions as props to children

### DIFF
--- a/src/components/multiStepModal/MultiStepModal.tsx
+++ b/src/components/multiStepModal/MultiStepModal.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import { Modal, ModalProps } from '../modal'
+import type { Context as ModalContext } from '../modal/Modal.context'
 import { MultiStepModalContext } from './MultiStepModal.context'
 import type { Step } from './MultiStepModal.context'
 import MultiStepModalBody from './body/MultiStepModal.Body'
@@ -8,9 +9,16 @@ import MultiStepModalFooter from './footer/MultiStepModal.Footer'
 import MultiStepModalHeader from './header/MultiStepModal.Header'
 import MultiStepModalProgressBar from './progressBar/MultiStepModal.ProgressBar'
 
+type ModalStepsRenderProps = ModalContext & {
+  currentStep: number
+  goToNextStep: () => void
+}
+type RenderProps = (props: ModalStepsRenderProps) => React.ReactNode
+
 export interface MultiStepModalProps extends ModalProps {
   defaultStepId?: string
   resetStepOnClose?: boolean
+  children: RenderProps | React.ReactNode
 }
 
 const MultiStepModal = ({
@@ -51,12 +59,17 @@ const MultiStepModal = ({
 
     if (onClose) onClose()
   }
+  const goToNextStep = stepsRegistered[currentStep + 1]
+    ? () => setCurrentStep(currentStep + 1)
+    : () => {}
 
   return (
     <MultiStepModalContext.Provider value={context}>
       <Modal {...rest} onClose={handleOnClose}>
         {modalProps =>
-          typeof children === 'function' ? children(modalProps) : children
+          typeof children === 'function'
+            ? children({ ...modalProps, currentStep, goToNextStep })
+            : children
         }
       </Modal>
     </MultiStepModalContext.Provider>

--- a/src/components/multiStepModal/footer/MultiStepModal.Footer.ContinueButton.tsx
+++ b/src/components/multiStepModal/footer/MultiStepModal.Footer.ContinueButton.tsx
@@ -7,7 +7,10 @@ import { useMultiStepModal } from '../MultiStepModal.context'
 
 type Props = ButtonProps
 
-const MultiStepModalFooterContinueButton: React.FC<Props> = (props: Props) => {
+const MultiStepModalFooterContinueButton: React.FC<Props> = ({
+  onClick,
+  ...props
+}: Props) => {
   const { currentStep, steps, setCurrentStep } = useMultiStepModal()
 
   const nextStep = steps[currentStep + 1]
@@ -22,7 +25,10 @@ const MultiStepModalFooterContinueButton: React.FC<Props> = (props: Props) => {
       variantColor="primary"
       variantSize="medium"
       rightIcon={CapUIIcon.LongArrowRight}
-      onClick={nextStep}
+      onClick={async (event: React.MouseEvent<any>) => {
+        if (onClick) onClick(event)
+        else nextStep()
+      }}
       {...props}
     >
       {steps[currentStep].validationLabel}

--- a/src/components/multiStepModal/index.tsx
+++ b/src/components/multiStepModal/index.tsx
@@ -1,4 +1,3 @@
 export { default as MultiStepModal } from './MultiStepModal'
 export type { MultiStepModalProps } from './MultiStepModal'
 export type { Step } from './MultiStepModal.context'
-export { useMultiStepModal } from './MultiStepModal.context'


### PR DESCRIPTION
#### :tophat: What? Why?
<!-- Describe your changes -->
`MultiStepModal` pass context actions as props to children


#### :art: Chromatic links
<!--
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=<PR number>)
[Storybook](https://<branch>--60ca00d41db7ba003be931d8.chromatic.com) 
-->

[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=254)
[Storybook](https://multi-step-modal-context--60ca00d41db7ba003be931d8.chromatic.com) 