### PR TITLE
[58] Fix prop onOpen & onClose

### DIFF
--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -129,6 +129,7 @@ export const Modal: React.FC<ModalProps> & SubComponents = ({
   })
 
   const containerRef = React.useRef<HTMLElement>(null)
+  const firstMount = React.useRef(true)
   const context = React.useMemo(
     () => ({
       hide: dialog.hide,
@@ -142,9 +143,10 @@ export const Modal: React.FC<ModalProps> & SubComponents = ({
   )
 
   React.useEffect(() => {
-    if (dialog.visible && onOpen) {
-      onOpen()
-    } else if (!dialog.visible && onClose) {
+    if (dialog.visible) {
+      if(onOpen) onOpen()
+      firstMount.current = false
+    } else if (!dialog.visible && onClose && !firstMount.current) {
       onClose()
     }
   }, [dialog.visible])

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -129,7 +129,6 @@ export const Modal: React.FC<ModalProps> & SubComponents = ({
   })
 
   const containerRef = React.useRef<HTMLElement>(null)
-  const firstMount = React.useRef(true)
   const context = React.useMemo(
     () => ({
       hide: dialog.hide,
@@ -143,15 +142,10 @@ export const Modal: React.FC<ModalProps> & SubComponents = ({
   )
 
   React.useEffect(() => {
-    if (dialog.visible && firstMount.current) {
-      if (onOpen) {
-        onOpen()
-      }
-      firstMount.current = false
-    } else if (!dialog.visible && !firstMount.current) {
-      if (onClose) {
-        onClose()
-      }
+    if (dialog.visible && onOpen) {
+      onOpen()
+    } else if (!dialog.visible && onClose) {
+      onClose()
     }
   }, [dialog.visible])
 


### PR DESCRIPTION
#### :tophat: What? Why?
Les props `onOpen` / `onClose` ne se déclenchaient pas lorsqu'on ouvrait / fermait la modal.

#### :pushpin: Related Issues
#58

#### :art: Chromatic links
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=256)
[Storybook](https://58-fix-props--60ca00d41db7ba003be931d8.chromatic.com) 