### PR TITLE
[33] Connect Search to form control

### DIFF
--- a/src/components/search/Search.stories.tsx
+++ b/src/components/search/Search.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, Story } from '@storybook/react'
 import * as React from 'react'
 
 import { Button } from '../button'
-import { CapInputSize, FormLabel } from '../form'
+import { CapInputSize, FormControl, FormLabel } from '../form';
 import Search from './Search'
 import mdx from './Search.mdx'
 
@@ -81,14 +81,10 @@ export const Controlled: Story<Args> = () => {
   )
 }
 
-const promiseOptions = (inputValue: string) =>
+const promiseOptions = () =>
   new Promise(resolve => {
     setTimeout(() => {
-      resolve(
-        colourOptions.filter(i =>
-          i.label.toLowerCase().includes(inputValue.toLowerCase()),
-        ),
-      )
+      resolve(colourOptions)
     }, 1000)
   })
 
@@ -104,4 +100,20 @@ export const WithSuggestions: Story<Args> = ({ ...args }) => (
       {...args}
     />
   </>
+)
+
+export const AsField: Story<Args> = ({ ...args }) => (
+  <FormControl>
+    <FormLabel label="Label" mb={1} />
+    <Search
+      {...args}
+      inputId="color"
+      loadOptions={promiseOptions}
+      defaultOptions
+      cacheOptions
+      filterOption={(option, input) => {
+        return option.label.toLowerCase().includes(input.toLowerCase());
+      }}
+    />
+  </FormControl>
 )


### PR DESCRIPTION
#### :tophat: What? Why?
Traitement des props du `Search` avec le `useFormControl` pour pouvoir l'utiliser dans un formulaire.

#### :pushpin: Related Issues
#33

#### :art: Chromatic links
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=)
[Storybook](https://33-control-search--60ca00d41db7ba003be931d8.chromatic.com) 