### PR TITLE
adding `goToStep` to `multiStepModal`

### DIFF
--- a/src/components/multiStepModal/MultiStepModal.tsx
+++ b/src/components/multiStepModal/MultiStepModal.tsx
@@ -12,6 +12,7 @@ import MultiStepModalProgressBar from './progressBar/MultiStepModal.ProgressBar'
 type ModalStepsRenderProps = ModalContext & {
   currentStep: number
   goToNextStep: () => void
+  goToStep: (index: number) => void
 }
 type RenderProps = (props: ModalStepsRenderProps) => React.ReactNode
 
@@ -63,12 +64,19 @@ const MultiStepModal = ({
     ? () => setCurrentStep(currentStep + 1)
     : () => {}
 
+  const goToStep = (index: number) => setCurrentStep(index)
+
   return (
     <MultiStepModalContext.Provider value={context}>
       <Modal {...rest} onClose={handleOnClose}>
         {modalProps =>
           typeof children === 'function'
-            ? children({ ...modalProps, currentStep, goToNextStep })
+            ? children({
+                ...modalProps,
+                currentStep,
+                goToNextStep,
+                goToStep,
+              })
             : children
         }
       </Modal>


### PR DESCRIPTION
#### :tophat: What? Why?
<!-- Describe your changes -->

this Is a proposition to add a function to go a specific step of a multistep modal
it's basically 
```js
const goToStep = (index: number) => setCurrentStep(index)
```
the need for this kind of control over the multistep-modal came from the SMS obviously and having dynamic multi step forms (Fun, i know)

this is in no way a permanent fix or the best way to handle this. The multiStepModal should be overhauled and remade according to the uses we have encountered.



#### :pushpin: Related Issues
<!-- What existing **issue(s)** does the pull request solve? -->
NA


#### :art: Chromatic links
<!--
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=<PR number>)
[Storybook](https://<branch>--60ca00d41db7ba003be931d8.chromatic.com) 
-->
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=273)
[Storybook](https://multistep-modal-step-control--60ca00d41db7ba003be931d8.chromatic.com) 