### PR TITLE
[272] Fix register steps

### DIFF
--- a/src/components/multiStepModal/progressBar/MultiStepModal.ProgressBar.tsx
+++ b/src/components/multiStepModal/progressBar/MultiStepModal.ProgressBar.tsx
@@ -18,7 +18,7 @@ const MultiStepModalProgressBar = () => {
   if (!steps[currentStep]) return null
 
   return (
-    <Flex direction="row" spacing={1} mt={6}>
+    <Flex direction="row" spacing={1}>
       {steps.map((step, idx) => (
         <Box key={step.id} bg="blue.200" height={1} flex={1}>
           <AnimatePresence initial={false}>


### PR DESCRIPTION
#### :tophat: What? Why?
Correction de l'enregistrement des étapes d'une modal multi étape.

**Actuellement**, ça enregistrait que lorsqu'il y avait pas encore d'étapes enregistrés.
Donc lorsqu'on modifiait les children, cela ne se mettait pas à jour.
**Maintenant**, on compare les étapes enregistrés avec les children.

#### :pushpin: Related Issues
#272

#### :art: Chromatic links
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=276)
[Storybook](https://272-fix-register--60ca00d41db7ba003be931d8.chromatic.com) 