### PR TITLE
1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ To better understand the changelog, here are some legends we use:
 
 `2022-07-19`
 
-- 🛠 Added Optional `Options` object to `Popover` component [#295](https://github.com/cap-collectif/ui/pull/295)
+- 🛠 Added Optional `Options` object to `Popover` component [#297](https://github.com/cap-collectif/ui/pull/297)
 
 ## 1.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ To better understand the changelog, here are some legends we use:
 - 🛠 Refactor
 - 💄 Style
 
+
+## 1.5.2
+
+`2022-07-19`
+
+- 🛠 Added Optional `Options` object to `Popover` component [#295](https://github.com/cap-collectif/ui/pull/295)
+
 ## 1.5.1
 
 `2022-07-07`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.1",
+  "version": "1.5.2",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## 1.5.2

`2022-07-19`

- 🛠 Added Optional `Options` object to `Popover` component [#297](https://github.com/cap-collectif/ui/pull/297)