### PR TITLE
[Fix] Pass Popover props to Popover

### DIFF
--- a/src/components/popover/Popover.stories.tsx
+++ b/src/components/popover/Popover.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 
 import { Popover, PopoverProps } from './'
 import mdx from './Popover.mdx'
+import { Flex } from '../layout'
 
 const meta: Meta<PopoverProps> = {
   title: 'Library/Popover',
@@ -42,4 +43,21 @@ export const WithFooter: Story<PopoverProps> = args => (
     </Popover.Body>
     <Popover.Footer>Lorem ipsum</Popover.Footer>
   </Popover>
+)
+export const WithBodyScroll: Story<PopoverProps> = args => (
+  <Flex height={800}>
+    <Popover
+      options={{ modal: true }}
+      popoverProps={{ preventBodyScroll: false }}
+      {...args}
+      disclosure={<button type="button">Open popover</button>}
+    >
+      <Popover.Header>Lorem ipsum</Popover.Header>
+      <Popover.Body>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent
+        facilisis ligula non nibh egestas efficitur.
+      </Popover.Body>
+      <Popover.Footer>Lorem ipsum</Popover.Footer>
+    </Popover>
+  </Flex>
 )

--- a/src/components/popover/Popover.tsx
+++ b/src/components/popover/Popover.tsx
@@ -21,6 +21,7 @@ import { PopoverContext } from './Popover.context'
 import PopoverBody from './body/PopoverBody'
 import PopoverFooter from './footer/PopoverFooter'
 import PopoverHeader from './header/PopoverHeader'
+import { DialogOptions } from 'reakit'
 
 type RenderChildren = ({
   closePopover,
@@ -43,6 +44,7 @@ export interface PopoverProps
   children: React.ReactNode | RenderChildren
   baseId?: string
   options?: PopoverInitialState
+  popoverProps?: Omit<DialogOptions, 'baseId'>
 }
 
 type ContainerAnimate = React.FC<
@@ -98,6 +100,7 @@ export const Popover: React.FC<PopoverProps> & SubComponents = ({
   placement = 'right',
   baseId,
   options,
+  popoverProps,
   ...props
 }: PopoverProps) => {
   const popover = usePopoverState({
@@ -126,7 +129,7 @@ export const Popover: React.FC<PopoverProps> & SubComponents = ({
       >
         {disclosureProps => React.cloneElement(disclosure, disclosureProps)}
       </PopoverDisclosure>
-      <StyledReakitPopover tabIndex={0} {...popover}>
+      <StyledReakitPopover tabIndex={0} {...popoverProps} {...popover}>
         <AnimatePresence>
           {popover.visible && (
             <ContainerAnimate


### PR DESCRIPTION
#### :tophat: What? Why?
<!-- Describe your changes -->

Pass `dialogProps` to Popover directly


#### :art: Chromatic links
<!--
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=<PR number>)
[Storybook](https://<branch>--60ca00d41db7ba003be931d8.chromatic.com) 
-->

[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=300)
[Storybook](https://fix-popover--60ca00d41db7ba003be931d8.chromatic.com) 