### PR TITLE
v1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ To better understand the changelog, here are some legends we use:
 - 🛠 Refactor
 - 💄 Style
 
+## 1.5.3
+
+`2022-07-26`
+
+- 🛠 Added Optional `popoverProps` object to `Popover` component [#300](https://github.com/cap-collectif/ui/pull/300)
+
 
 ## 1.5.2
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.2",
+  "version": "1.5.3",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## 1.5.3

`2022-07-26`

- 🛠 Added Optional `popoverProps` object to `Popover` component [#300](https://github.com/cap-collectif/ui/pull/300)
