### PR TITLE
v1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ To better understand the changelog, here are some legends we use:
 
 ## 1.5.4
 
-`2022-07-26`
+`2022-08-11`
 
 - 🐛 Added `type="button"` to buttons to avoid submitting forms [#302](https://github.com/cap-collectif/ui/pull/302)
 


### PR DESCRIPTION
## 1.5.4

`2022-08-11`

- 🐛 Added `type="button"` to buttons to avoid submitting forms [#302](https://github.com/cap-collectif/ui/pull/302)
