### PR TITLE
add accordion transparent variant

### DIFF
--- a/src/components/accordion/Accordion.stories.tsx
+++ b/src/components/accordion/Accordion.stories.tsx
@@ -52,3 +52,13 @@ VariantGray.parameters = {
     default: 'undefined',
   },
 }
+
+export const VariantTransparent = Template.bind({})
+VariantTransparent.args = {
+  color: CapUIAccordionColor.Transparent,
+}
+VariantTransparent.parameters = {
+  backgrounds: {
+    default: 'undefined',
+  },
+}

--- a/src/components/accordion/Accordion.tsx
+++ b/src/components/accordion/Accordion.tsx
@@ -54,9 +54,21 @@ export const Accordion: React.FC<AccordionProps> & SubComponents = ({
     ],
   )
 
+  const variants: Record<CapUIAccordionColor, { spacing: number }> = {
+    'white': {
+      spacing: 4
+    },
+    'gray': {
+      spacing: 4
+    },
+    'transparent': {
+      spacing: 0
+    }
+  }
+
   return (
     <AccordionContext.Provider value={context}>
-      <Flex direction="column" spacing={4} {...props}>
+      <Flex direction="column" spacing={variants[color].spacing} {...props}>
         {children}
       </Flex>
     </AccordionContext.Provider>

--- a/src/components/accordion/button/AccordionButton.tsx
+++ b/src/components/accordion/button/AccordionButton.tsx
@@ -32,6 +32,27 @@ const AccordionButton: React.FC<AccordionButtonProps> = ({
     toggleOpen()
   }, [disabled, toggleOpen])
 
+  const variants: Record<CapUIAccordionColor, { fontWeight: CapUIFontWeight, color: string, px: number, pb: number }> = {
+    'white': {
+      fontWeight: CapUIFontWeight.Bold,
+      color: 'blue.800',
+      px: 6,
+      pb: 6,
+    },
+    'gray': {
+      fontWeight: CapUIFontWeight.Normal,
+      color: 'gray.900',
+      px: 6,
+      pb: 6,
+    },
+    'transparent': {
+      fontWeight: CapUIFontWeight.Normal,
+      color: 'gray.900',
+      px: 0,
+      pb: 4,
+    }
+  }
+
   return (
     <Flex
       as="button"
@@ -40,8 +61,9 @@ const AccordionButton: React.FC<AccordionButtonProps> = ({
       disabled={disabled}
       onClick={toggle}
       align="center"
-      p={6}
-      pb={open && size === CapUIAccordionSize.Sm ? 4 : 6}
+      px={variants[color].px}
+      py={variants[color].pb}
+      pb={open && size === CapUIAccordionSize.Sm ? 4 : variants[color].pb}
       width="100%"
       fontWeight={CapUIFontWeight.Normal}
       className={cn('cap-accordion__button', className)}
@@ -60,14 +82,10 @@ const AccordionButton: React.FC<AccordionButtonProps> = ({
 
       {typeof children === 'string' ? (
         <Text
-          color={color === CapUIAccordionColor.Gray ? 'gray.900' : 'blue.800'}
+          color={variants[color].color}
           fontSize={3}
           {...(size === CapUIAccordionSize.Sm ? {} : headingStyles.h4)}
-          fontWeight={
-            color === CapUIAccordionColor.White
-              ? CapUIFontWeight.Bold
-              : CapUIFontWeight.Normal
-          }
+          fontWeight={variants[color].fontWeight}
         >
           {children}
         </Text>

--- a/src/components/accordion/enums.ts
+++ b/src/components/accordion/enums.ts
@@ -6,4 +6,5 @@ export enum CapUIAccordionSize {
 export enum CapUIAccordionColor {
   White = 'white',
   Gray = 'gray',
+  Transparent = 'transparent',
 }

--- a/src/components/accordion/item/AccordionItem.tsx
+++ b/src/components/accordion/item/AccordionItem.tsx
@@ -30,20 +30,35 @@ const AccordionItem: React.FC<AccordionItemProps> = ({
     [isOpen, id, updateAccordions],
   )
 
+  const variants: Record<CapUIAccordionColor, { bg: string, bgOpen: string, border: string, pbOpen: number }> = {
+    white: {
+      bg: 'white',
+      bgOpen: 'blue.100',
+      border: 'none',
+      pbOpen: 6
+    },
+    gray: {
+      bg: 'gray.100',
+      bgOpen: 'gray.100',
+      border: 'normal',
+      pbOpen: 6
+    },
+    transparent: {
+      bg: 'transparent',
+      bgOpen: 'transparent',
+      border: 'none',
+      pbOpen: 4
+    },
+  }
+
   return (
     <AccordionItemContext.Provider value={context}>
       <Box
         id={id}
-        bg={
-          color === CapUIAccordionColor.White
-            ? 'white'
-            : isOpen
-            ? 'blue.100'
-            : 'gray.100'
-        }
+        bg={isOpen ? variants[color].bgOpen : variants[color].bg}
         className={cn('cap-accordion__item', className)}
         borderRadius="accordion"
-        border={color === CapUIAccordionColor.Gray ? 'normal' : 'none'}
+        border={variants[color].border}
         borderColor={isOpen ? 'blue.500' : 'gray.200'}
         _hover={{
           borderColor: 'gray.300',
@@ -51,7 +66,7 @@ const AccordionItem: React.FC<AccordionItemProps> = ({
         _disabled={{
           opacity: 0.5,
         }}
-        pb={isOpen ? 6 : 0}
+        pb={isOpen ? variants[color].pbOpen : 0}
         {...props}
       >
         {children}


### PR DESCRIPTION
#### :tophat: What? Why?
<!-- Describe your changes -->
Ajout de la variant transparent sur le composant Accordeon
on enlève le background, on réduit les espacements et on enlève le padding à gauche

#### :pushpin: Related Issues
<!-- What existing **issue(s)** does the pull request solve? -->

#### :clipboard: Technical Specification
<!-- Describe how you plan to solve the problem
- [x] Subtask 1
- [ ] Subtask 2
-->

#### :art: Chromatic links
<!--
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=<PR number>)
[Storybook](https://<branch>--60ca00d41db7ba003be931d8.chromatic.com) 
-->
https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=330
https://www.chromatic.com/component?appId=60ca00d41db7ba003be931d8&csfId=library-accordion--variant-transparent&buildNumber=625&k=63b7e27478a897d380ecc8a6-1200-interactive-true&h=13&b=-6

#### :camera_flash: Screenshots
<!-- Screenshots if appropriate -->