### PR TITLE
remove useHotkeys in InlineSelect

### DIFF
--- a/src/components/inlineSelect/choice/InlineSelectChoice.tsx
+++ b/src/components/inlineSelect/choice/InlineSelectChoice.tsx
@@ -1,6 +1,5 @@
 import cn from 'classnames'
 import * as React from 'react'
-import { useHotkeys } from 'react-hotkeys-hook'
 
 import { CapUIFontFamily, CapUILineHeight } from '../../../styles'
 import { Box, BoxProps } from '../../box/Box'
@@ -26,8 +25,6 @@ export const InlineSelectChoice: React.FC<InlineSelectChoiceProps> = ({
     }
   }, [onChange, value])
 
-  const elementRef = useHotkeys('space, enter', handler, [handler])
-
   return (
     <Box
       as="li"
@@ -42,7 +39,6 @@ export const InlineSelectChoice: React.FC<InlineSelectChoiceProps> = ({
         <Box
           as="button"
           type="button"
-          ref={elementRef}
           onClick={handler}
           color="gray.500"
           bg="transparent"


### PR DESCRIPTION
#### :tophat: What? Why?
<!-- Describe your changes -->
Dans le compo `InlineSelectChoice` le `useHotKeys` bind la touche entrée sur la `Box`, ça créer un conflit avec tous les autres éléments de la page qui peuvent être actionné avec la touche Entrée
Le fonctionnement voulu fonctionne nativement du coup on peut supprimer l'utilisation du hook

#### :pushpin: Related Issues
<!-- What existing **issue(s)** does the pull request solve? -->

#### :clipboard: Technical Specification
<!-- Describe how you plan to solve the problem
- [x] Subtask 1
- [ ] Subtask 2
-->

#### :art: Chromatic links
<!--
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=<PR number>)
[Storybook](https://<branch>--60ca00d41db7ba003be931d8.chromatic.com) 
-->

#### :camera_flash: Screenshots
<!-- Screenshots if appropriate -->