### PR TITLE
1.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ To better understand the changelog, here are some legends we use:
 - 💄 Style
 
 
+## 1.5.8
+
+`2023-01-23`
+
+- 💄 Adds `HourInput` styles on `InputGroup`  [#337](https://github.com/cap-collectif/ui/pull/337)
+- 🐛 Remove `useHotkeys` in `InlineSelect` [#335](https://github.com/cap-collectif/ui/pull/335)
+- 🐛 Fix `Accordion` background [#336](https://github.com/cap-collectif/ui/pull/336)
+
 ## 1.5.7
 
 `2023-01-12`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.7",
+  "version": "1.5.8",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## 1.5.8

`2023-01-23`

- 💄 Adds `HourInput` styles on `InputGroup`  [#337](https://github.com/cap-collectif/ui/pull/337)
- 🐛 Remove `useHotkeys` in `InlineSelect` [#335](https://github.com/cap-collectif/ui/pull/335)
- 🐛 Fix `Accordion` background [#336](https://github.com/cap-collectif/ui/pull/336)