### PR TITLE
1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ To better understand the changelog, here are some legends we use:
 - 🛠 Refactor
 - 💄 Style
 
+## 1.6.3
+
+`2023-03-14`
+
+- 🐛 Fix `Input` type for `onClickActions` methods  [#354](https://github.com/cap-collectif/ui/pull/354)
+
 ## 1.6.2
 
 `2023-03-13`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.2",
+  "version": "1.6.3",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## 1.6.3

`2023-03-14`

- 🐛 Fix `Input` type for `onClickActions` methods  [#354](https://github.com/cap-collectif/ui/pull/354)