### PR TITLE
Variant "smoothWorkflow" on multistepmodal

### DIFF
--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -105,6 +105,12 @@ const ModalInner = styled(motion(Flex)).attrs(
         borderTopRightRadius: '0',
         borderBottomRightRadius: '0',
       },
+      fullscreen: {
+        width: '100%',
+        height: '100%',
+        mt: '0',
+        borderRadius: '0',
+      },
     },
   }),
 ) as StyledComponent<any, any>
@@ -212,7 +218,10 @@ export const Modal: React.FC<ModalProps> & SubComponents = ({
               exit={{ opacity: 0 }}
               className="cap-modal__overlay"
               zIndex={zIndex || 'overlay'}
-              isSidePanel={size === CapUIModalSize.SidePanel}
+              isSidePanel={
+                size === CapUIModalSize.SidePanel ||
+                size === CapUIModalSize.Fullscreen
+              }
             >
               <ModalInner
                 direction="column"

--- a/src/components/modal/enums.ts
+++ b/src/components/modal/enums.ts
@@ -4,4 +4,5 @@ export enum CapUIModalSize {
   Lg = 'lg',
   Xl = 'xl',
   SidePanel = 'sidePanel',
+  Fullscreen = 'fullscreen',
 }

--- a/src/components/multiStepModal/MultiStepModal.context.tsx
+++ b/src/components/multiStepModal/MultiStepModal.context.tsx
@@ -14,6 +14,7 @@ export type Context = ModalContext & {
   currentStep: number
   totalSteps: number
   direction: DIRECTION
+  smoothWorkflow: boolean
   setCurrentStep: (stepIndex: number) => void
   goToPreviousStep: () => void
   goToNextStep: () => void
@@ -24,6 +25,7 @@ export const MultiStepModalContext = React.createContext<Context>({
   currentStep: 0,
   totalSteps: 0,
   direction: DIRECTION.RIGHT,
+  smoothWorkflow: false,
   setCurrentStep: () => {},
   goToPreviousStep: () => {},
   goToNextStep: () => {},

--- a/src/components/multiStepModal/MultiStepModal.stories.tsx
+++ b/src/components/multiStepModal/MultiStepModal.stories.tsx
@@ -1,7 +1,11 @@
 import { Meta, Story } from '@storybook/react'
 import * as React from 'react'
 
+import { Box } from '../box'
 import { Button } from '../button'
+import { FormLabel, Input } from '../form'
+import { CapUIIcon, CapUIIconSize, Icon } from '../icon'
+import { Flex } from '../layout'
 import { CapUIModalSize } from '../modal'
 import { Text } from '../typography'
 import { Heading } from '../typography/Heading'
@@ -219,5 +223,148 @@ export const ConditionalStep: Story<MultiStepModalProps> = () => {
       {displayStep && <ModalTwo />}
       <ModalThree />
     </MultiStepModal>
+  )
+}
+
+const Step = ({
+  title,
+  info,
+  label,
+  placeholder,
+  onClose,
+  firstStep,
+  lastStep,
+}: {
+  title: string
+  info: string
+  label?: string
+  placeholder?: string
+  onClose: () => void
+  firstStep?: boolean
+  lastStep?: boolean
+}) => {
+  const { goToNextStep, goToPreviousStep } = useMultiStepModal()
+
+  return (
+    <>
+      <MultiStepModal.Header>
+        <Flex
+          alignItems="center"
+          justifyContent="space-between"
+          position="relative"
+        >
+          <Box position="absolute" left={0} display={['none', 'block']}>
+            LOGO
+          </Box>
+          <Flex
+            justifyContent="space-between"
+            alignItems="center"
+            margin="auto"
+            maxWidth="540px"
+            width="100%"
+          >
+            <Icon
+              cursor="pointer"
+              onClick={firstStep ? () => {} : goToPreviousStep}
+              name={CapUIIcon.LongArrowLeft}
+              size={CapUIIconSize.Md}
+              color="neutral-gray.500"
+            />
+            <Box textAlign="center">
+              <Heading>Informations requises</Heading>
+              <Text display={['none', 'block']}>
+                Validation votre participation en cours
+              </Text>
+            </Box>
+            <Icon
+              cursor="pointer"
+              onClick={onClose}
+              name={CapUIIcon.CrossO}
+              size={CapUIIconSize.Md}
+              color="neutral-gray.500"
+            />
+          </Flex>
+        </Flex>
+      </MultiStepModal.Header>
+
+      <MultiStepModal.Body bg="neutral-gray.50">
+        <Flex
+          py={13}
+          direction="column"
+          justifyContent="center"
+          alignItems="center"
+          margin="auto"
+          maxWidth="540px"
+        >
+          <Heading mb={4} as="h3">
+            {title}
+          </Heading>
+          <Text mb={4} textAlign="center" color="neutral-gray.700" fontSize={3}>
+            {info}
+          </Text>
+          {lastStep ? null : (
+            <Box width="100%" mb={4}>
+              <FormLabel label={label || ''} mb={1} />
+              <Input placeholder={placeholder} />
+            </Box>
+          )}
+          <Button
+            variantSize="big"
+            onClick={lastStep ? onClose : goToNextStep}
+            justifyContent="center"
+            width="100%"
+          >
+            {lastStep ? 'Valider !' : 'Continuer'}
+          </Button>
+        </Flex>
+      </MultiStepModal.Body>
+    </>
+  )
+}
+
+export const FullScreen: Story<MultiStepModalProps> = () => {
+  const [show, setShow] = React.useState(false)
+
+  return (
+    <>
+      <Button
+        variant="primary"
+        variantSize="medium"
+        onClick={() => setShow(true)}
+      >
+        Valider ma participation
+      </Button>
+      <MultiStepModal
+        ariaLabel="Fullscreen"
+        size={CapUIModalSize.Fullscreen}
+        smoothWorkflow
+        hideCloseButton
+        onClose={() => setShow(false)}
+        show={show}
+        fullSizeOnMobile
+      >
+        <Step
+          firstStep
+          onClose={() => setShow(false)}
+          title="Quelle est votre adresse e-mail ?"
+          info="Pour une participation plus sûre, fiable et authentique et vous permet de gérer votre participation."
+          placeholder="prenom.nom@mail.com"
+          label="Email"
+        />
+        <Step
+          onClose={() => setShow(false)}
+          title="Avez-vous un pseudonyme ?"
+          info="Il sera visible sur votre profil et sur vos participations"
+          placeholder="ex : John.D"
+          label="Pseudonyme"
+        />
+        <Step
+          onClose={() => setShow(false)}
+          lastStep
+          title="Merci"
+          info="Si vous êtes sur de vos informations, cliquer pour valider votre participation. Sinon, revenez en arrière"
+        />
+      </MultiStepModal>
+    </>
   )
 }

--- a/src/components/multiStepModal/MultiStepModal.tsx
+++ b/src/components/multiStepModal/MultiStepModal.tsx
@@ -16,6 +16,7 @@ export interface MultiStepModalProps extends ModalProps {
   defaultStep?: number
   resetStepOnClose?: boolean
   children: React.ReactNode
+  smoothWorkflow?: boolean
 }
 
 const MultiStepModal: React.FC<MultiStepModalProps> & SubComponents = ({
@@ -23,6 +24,7 @@ const MultiStepModal: React.FC<MultiStepModalProps> & SubComponents = ({
   defaultStep,
   resetStepOnClose = true,
   onClose,
+  smoothWorkflow = false,
   ...rest
 }) => {
   const [currentStep, setCurrentStep] = React.useState(defaultStep || 0)
@@ -33,6 +35,7 @@ const MultiStepModal: React.FC<MultiStepModalProps> & SubComponents = ({
       currentStep,
       totalSteps: React.Children.toArray(children).length,
       direction,
+      smoothWorkflow,
       setCurrentStep,
       goToPreviousStep: () => {
         setCurrentStep(currentStep - 1)

--- a/src/components/multiStepModal/progressBar/MultiStepModalProgressBar.tsx
+++ b/src/components/multiStepModal/progressBar/MultiStepModalProgressBar.tsx
@@ -14,27 +14,41 @@ const variants = {
 }
 
 const MultiStepModalProgressBar = () => {
-  const { totalSteps, currentStep, direction } = useMultiStepModal()
-
-  const steps = React.useMemo(() => Array.from(Array(totalSteps).keys()), [
+  const {
     totalSteps,
-  ])
+    currentStep,
+    direction,
+    smoothWorkflow,
+  } = useMultiStepModal()
+
+  const total = smoothWorkflow ? totalSteps * 2 : totalSteps
+
+  const steps = React.useMemo(() => Array.from(Array(total).keys()), [total])
+
+  const fillIndex = smoothWorkflow ? totalSteps : 0
 
   return (
     <Flex
       direction="row"
-      spacing={1}
+      spacing={smoothWorkflow ? 0 : 1}
       position="absolute"
       width="100%"
       left={0}
       bottom={0}
     >
       {steps.map(step => (
-        <Box key={`item-${step}`} bg="blue.200" height={1} flex={1}>
+        <Box
+          key={`item-${step}`}
+          bg="blue.200"
+          height={smoothWorkflow ? 0.5 : 1}
+          flex={1}
+        >
           <AnimatePresence
-            initial={step === currentStep && direction !== DIRECTION.LEFT}
+            initial={
+              step === currentStep + fillIndex && direction !== DIRECTION.LEFT
+            }
           >
-            {step <= currentStep && (
+            {step <= currentStep + fillIndex && (
               <ItemFillProgressBar
                 key={`item-fill-${step}`}
                 height="100%"
@@ -43,6 +57,12 @@ const MultiStepModalProgressBar = () => {
                 animate="fill"
                 variants={variants}
                 transition={{ duration: 0.3, ease }}
+                borderTopRightRadius={
+                  smoothWorkflow && step === currentStep + fillIndex ? 1 : 0
+                }
+                borderBottomRightRadius={
+                  smoothWorkflow && step === currentStep + fillIndex ? 1 : 0
+                }
               />
             )}
           </AnimatePresence>

--- a/src/styles/theme/index.ts
+++ b/src/styles/theme/index.ts
@@ -67,6 +67,7 @@ export const breakpoints: Breakpoints = {
 export const SPACING = {
   px: '1px',
   0: 0,
+  0.5: pxToRem(2),
   1: pxToRem(4),
   2: pxToRem(8),
   3: pxToRem(12),


### PR DESCRIPTION
#### :tophat: What? Why?
<!-- Describe your changes -->
La prop `smoothWorkflow` va rendre la barre d'étape différemment, en y ajoutant au passage un départ à la moitié + 1 . À affiner une fois en test sur des données réelles, mais content pour un premier rendu !

[J'ai fais un exemple assez complet](https://multistepmodal-variant--60ca00d41db7ba003be931d8.chromatic.com/?path=/story/library-multistepmodal--full-screen)



#### :clipboard: Technical Specification
<!-- Describe how you plan to solve the problem
- [x] Subtask 1
- [ ] Subtask 2
-->

#### :art: Chromatic links
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=378)
[Storybook](https://multistepmodal-variant--60ca00d41db7ba003be931d8.chromatic.com) 

#### :camera_flash: Screenshots
<!-- Screenshots if appropriate -->