### PR TITLE
POC - Customisation avancée de la couleur du DS

### DIFF
--- a/src/WithCustomTheme.stories.tsx
+++ b/src/WithCustomTheme.stories.tsx
@@ -5,6 +5,7 @@ import {
   Accordion,
   AvatarGroup,
   Button,
+  CapUIAccordionColor,
   CapUIProvider,
   Checkbox,
   ColorPicker,
@@ -12,7 +13,6 @@ import {
   Input,
   Radio,
   Search,
-  Select,
   Switch,
   Uploader,
 } from './'
@@ -99,7 +99,7 @@ export const Default: Story<Props> = ({
           <ColorPicker />
         </Flex>
         <Flex mt={4}>
-          <Accordion color="gray">
+          <Accordion color={CapUIAccordionColor.Gray}>
             <Accordion.Item id="volet-1">
               <Accordion.Button>Volet 1</Accordion.Button>
               <Accordion.Panel>Contenu du volet 1</Accordion.Panel>

--- a/src/WithCustomTheme.stories.tsx
+++ b/src/WithCustomTheme.stories.tsx
@@ -1,0 +1,143 @@
+import { Meta, Story } from '@storybook/react'
+import * as React from 'react'
+
+import {
+  Accordion,
+  AvatarGroup,
+  Button,
+  CapUIProvider,
+  Checkbox,
+  ColorPicker,
+  Flex,
+  Input,
+  Radio,
+  Search,
+  Select,
+  Switch,
+  Uploader,
+} from './'
+import Avatar from './components/avatar/Avatar'
+import { capuiTheme } from './styles/theme'
+
+const meta: Meta<Props> = {
+  title: 'WithCustomTheme',
+  parameters: {
+    layout: 'centered',
+    controls: { expanded: true },
+  },
+}
+
+export default meta
+
+type Props = {
+  primary: string
+  primaryLabel: string
+  primaryHover: string
+  primaryLabelHover: string
+}
+
+export const Default: Story<Props> = ({
+  primary,
+  primaryLabel,
+  primaryHover,
+  primaryLabelHover,
+}) => {
+  const CustomTheme = {
+    ...capuiTheme,
+    colors: {
+      ...capuiTheme.colors,
+      primary,
+      primaryLabel,
+      primaryHover,
+      primaryLabelHover,
+    },
+  }
+
+  return (
+    <>
+      <CapUIProvider theme={CustomTheme}>
+        <Flex gap={4}>
+          <Button variantSize="big" variant="primary">
+            Primary
+          </Button>
+          <Button variantSize="big" variant="secondary">
+            Secondary
+          </Button>
+          <Button variantSize="big" variant="tertiary">
+            Tertiary
+          </Button>
+          <Button variantSize="big" variant="link">
+            Link
+          </Button>
+        </Flex>
+        <Flex gap={4} mt={4}>
+          <Input />
+          <Search
+            onChange={() => {}}
+            inputId="search"
+            loadOptions={() =>
+              new Promise(resolve => {
+                setTimeout(() => {
+                  resolve([])
+                }, 1000)
+              })
+            }
+            defaultOptions
+            cacheOptions
+          />
+        </Flex>
+        <Flex gap={4} mt={4} alignItems="center">
+          <Switch id="example" />
+          <Radio id="radio" />
+          <Checkbox id="checkbox" />
+          <AvatarGroup max={2}>
+            <Avatar name="Mikasa Estucasa" />
+            <Avatar name="Dan Abramov" src="https://bit.ly/dan-abramov" />
+            <Avatar name="John Mark" />
+          </AvatarGroup>
+          {/** @ts-expect-error Example only */}
+          <ColorPicker />
+        </Flex>
+        <Flex mt={4}>
+          <Accordion color="gray">
+            <Accordion.Item id="volet-1">
+              <Accordion.Button>Volet 1</Accordion.Button>
+              <Accordion.Panel>Contenu du volet 1</Accordion.Panel>
+            </Accordion.Item>
+          </Accordion>
+        </Flex>
+        <Flex mt={4}>
+          <Uploader
+            wording={{
+              uploaderPrompt: 'Déposer ou sélectionner des fichiers',
+              uploaderLoadingPrompt: 'Importation en cours...',
+              fileDeleteLabel: 'Supprimer',
+            }}
+            onDrop={() => {}}
+          />
+        </Flex>
+      </CapUIProvider>
+    </>
+  )
+}
+
+Default.args = {
+  primary: '#ff9909',
+  primaryLabel: '#fff',
+  primaryHover: '#c27a15',
+  primaryLabelHover: '#fff',
+}
+Default.argTypes = {
+  primary: {
+    control: { type: 'color' },
+  },
+  primaryLabel: {
+    control: { type: 'color' },
+  },
+  primaryHover: {
+    control: { type: 'color' },
+  },
+  primaryLabelHover: {
+    control: { type: 'color' },
+  },
+}

--- a/src/components/accordion/button/AccordionButton.tsx
+++ b/src/components/accordion/button/AccordionButton.tsx
@@ -32,25 +32,28 @@ const AccordionButton: React.FC<AccordionButtonProps> = ({
     toggleOpen()
   }, [disabled, toggleOpen])
 
-  const variants: Record<CapUIAccordionColor, { fontWeight: CapUIFontWeight, color: string, px: number, pb: number }> = {
-    'white': {
+  const variants: Record<
+    CapUIAccordionColor,
+    { fontWeight: CapUIFontWeight; color: string; px: number; pb: number }
+  > = {
+    white: {
       fontWeight: CapUIFontWeight.Bold,
       color: 'blue.800',
       px: 6,
       pb: 6,
     },
-    'gray': {
+    gray: {
       fontWeight: CapUIFontWeight.Normal,
       color: 'gray.900',
       px: 6,
       pb: 6,
     },
-    'transparent': {
+    transparent: {
       fontWeight: CapUIFontWeight.Normal,
       color: 'gray.900',
       px: 0,
       pb: 4,
-    }
+    },
   }
 
   return (
@@ -77,7 +80,7 @@ const AccordionButton: React.FC<AccordionButtonProps> = ({
         name={open ? CapUIIcon.ArrowDown : CapUIIcon.ArrowRight}
         size={CapUIIconSize.Md}
         mr={2}
-        color={open ? 'blue.500' : 'gray.500'}
+        color={open ? 'primary' : 'gray.500'}
       />
 
       {typeof children === 'string' ? (

--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -110,7 +110,7 @@ export const Avatar = ({
 
   return (
     <AvatarInner
-      bg="blue.500"
+      bg="primary"
       color="aqua.100"
       className={cn('cap-avatar', className)}
       title={shouldDisplayName ? alt : name}

--- a/src/components/avatarGroup/AvatarGroup.tsx
+++ b/src/components/avatarGroup/AvatarGroup.tsx
@@ -67,7 +67,7 @@ export const AvatarGroup = ({
           {...avatarStyles}
           {...variantsAvatarSize[size]}
           mr={getMarginForSize(size)}
-          bg="blue.500"
+          bg="primary"
           color="white"
           borderColor="white"
           border="avatar"

--- a/src/components/button/Button.style.ts
+++ b/src/components/button/Button.style.ts
@@ -1,84 +1,83 @@
-import colors from '../../styles/modules/colors'
+import { Colors } from '../../styles/modules/colors'
 import typography, { CapUIFontWeight } from '../../styles/theme/typography'
+import { newShade } from '../../utils/color'
 
-const styles = (alternative?: boolean) => ({
+const styles = (alternative?: boolean, colors?: Colors) => ({
   common: {
     outline: 'none',
   },
   primary: {
     primary: {
-      bg: 'blue.500',
-      color: 'blue.100',
+      bg: 'primary',
+      color: 'primaryLabel',
 
       '&:focus': {
-        boxShadow: `0 0 2px 2px ${colors.blue['300']}`,
+        boxShadow: `0 0 2px 2px ${colors?.primaryHover}`,
       },
 
       '&:hover': {
-        bg: 'blue.700',
-        color: 'blue.100',
+        bg: 'primaryHover',
+        color: 'primaryLabelHover',
       },
 
       '&:disabled': {
-        bg: 'blue.150',
-        color: 'blue.300',
+        opacity: 0.4,
       },
     },
     secondary: {
       bg: 'white',
-      color: 'blue.500',
+      color: 'primary',
       border: 'button',
-      borderColor: 'blue.500',
+      borderColor: 'primary',
 
       '&:focus': {
-        boxShadow: `0 0 2px 2px ${colors.blue['300']}`,
+        boxShadow: `0 0 2px 2px ${colors?.primaryHover}`,
       },
 
       '&:hover': {
-        color: 'blue.700',
-        borderColor: 'blue.700',
+        color: 'primaryHover',
+        borderColor: 'primaryHover',
       },
 
       '&:disabled': {
-        color: 'blue.300',
-        borderColor: 'blue.300',
+        opacity: 0.4,
       },
     },
     tertiary: {
       bg: 'transparent',
-      color: 'blue.500',
+      color: 'primary',
       p: 0,
       textTransform: alternative ? 'uppercase' : 'initial',
       fontSize: alternative ? typography.fontSizes[1] : typography.fontSizes[3],
 
       '&:focus': {
-        boxShadow: `0 0 2px 2px ${colors.blue['300']}`,
+        boxShadow: `0 0 2px 2px ${colors?.primaryHover}`,
       },
 
       '&:hover': {
-        color: 'blue.700',
+        color: 'primaryHover',
       },
 
       '&:disabled': {
-        color: 'blue.300',
+        opacity: 0.4,
       },
     },
     link: {
       textDecoration: 'underline',
-      color: 'blue.500',
+      color: 'primary',
       fontWeight: CapUIFontWeight.Normal,
       p: 0,
 
       '&:focus': {
-        boxShadow: `0 0 2px 2px ${colors.blue['300']}`,
+        boxShadow: `0 0 2px 2px ${colors?.primaryHover}`,
       },
 
       '&:hover': {
-        color: 'blue.700',
+        color: 'primaryHover',
       },
 
       '&:disabled': {
-        color: 'blue.300',
+        opacity: 0.4,
       },
     },
   },
@@ -88,7 +87,7 @@ const styles = (alternative?: boolean) => ({
       color: 'red.100',
 
       '&:focus': {
-        boxShadow: `0 0 2px 2px ${colors.red['300']}`,
+        boxShadow: `0 0 2px 2px ${colors?.red['300']}`,
       },
 
       '&:hover': {
@@ -106,7 +105,7 @@ const styles = (alternative?: boolean) => ({
       borderColor: 'red.500',
 
       '&:focus': {
-        boxShadow: `0 0 2px 2px ${colors.red['300']}`,
+        boxShadow: `0 0 2px 2px ${colors?.red['300']}`,
       },
 
       '&:hover': {
@@ -126,7 +125,7 @@ const styles = (alternative?: boolean) => ({
       fontSize: alternative ? typography.fontSizes[1] : typography.fontSizes[3],
 
       '&:focus': {
-        boxShadow: `0 0 2px 2px ${colors.red['300']}`,
+        boxShadow: `0 0 2px 2px ${colors?.red['300']}`,
       },
 
       '&:hover': {
@@ -144,7 +143,7 @@ const styles = (alternative?: boolean) => ({
       p: 0,
 
       '&:focus': {
-        boxShadow: `0 0 2px 2px ${colors.red['300']}`,
+        boxShadow: `0 0 2px 2px ${colors?.red['300']}`,
       },
 
       '&:hover': {
@@ -162,7 +161,7 @@ const styles = (alternative?: boolean) => ({
       color: 'gray.100',
 
       '&:focus': {
-        boxShadow: `0 0 2px 2px ${colors.gray['300']}`,
+        boxShadow: `0 0 2px 2px ${colors?.gray['300']}`,
       },
 
       '&:hover': {
@@ -181,7 +180,7 @@ const styles = (alternative?: boolean) => ({
       borderColor: 'gray.500',
 
       '&:focus': {
-        boxShadow: `0 0 2px 2px ${colors.gray['300']}`,
+        boxShadow: `0 0 2px 2px ${colors?.gray['300']}`,
       },
 
       '&:hover': {
@@ -200,7 +199,7 @@ const styles = (alternative?: boolean) => ({
       p: 0,
 
       '&:focus': {
-        boxShadow: `0 0 2px 2px ${colors.gray['300']}`,
+        boxShadow: `0 0 2px 2px ${colors?.gray['300']}`,
       },
 
       '&:hover': {
@@ -218,7 +217,7 @@ const styles = (alternative?: boolean) => ({
       p: 0,
 
       '&:focus': {
-        boxShadow: `0 0 2px 2px ${colors.gray['300']}`,
+        boxShadow: `0 0 2px 2px ${colors?.gray['300']}`,
       },
 
       '&:hover': {

--- a/src/components/button/Button.style.ts
+++ b/src/components/button/Button.style.ts
@@ -1,6 +1,5 @@
 import { Colors } from '../../styles/modules/colors'
 import typography, { CapUIFontWeight } from '../../styles/theme/typography'
-import { newShade } from '../../utils/color'
 
 const styles = (alternative?: boolean, colors?: Colors) => ({
   common: {

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -3,7 +3,9 @@ import * as React from 'react'
 import styled from 'styled-components'
 import { variant as variantStyled } from 'styled-system'
 
+import { useTheme } from '../../hooks'
 import { CapUIFontWeight, CapUILineHeight } from '../../styles'
+import { Colors } from '../../styles/modules/colors'
 import { Box } from '../box'
 import { PolymorphicComponentProps } from '../box/Box'
 import { CapUIIcon, CapUIIconSize, Icon } from '../icon'
@@ -42,22 +44,26 @@ const SIZE = {
 }
 
 const ButtonInner = styled(Box)(
-  S().common,
+  S(false).common,
   ({
     variantColor = 'primary',
     alternative,
+    colors,
   }: {
     variantColor: ButtonProps['variantColor']
     alternative: boolean
-  }) =>
-    variantStyled({
+    colors: Colors
+  }) => {
+    console.log('c', colors)
+    return variantStyled({
       variants: {
-        primary: S()[variantColor].primary,
-        secondary: S()[variantColor].secondary,
-        tertiary: S(alternative)[variantColor].tertiary,
-        link: S()[variantColor].link,
+        primary: S(false, colors)[variantColor].primary,
+        secondary: S(false, colors)[variantColor].secondary,
+        tertiary: S(alternative, colors)[variantColor].tertiary,
+        link: S(false, colors)[variantColor].link,
       },
-    }),
+    })
+  },
 )
 
 const Button: React.FC<ButtonProps> = React.forwardRef<
@@ -81,6 +87,7 @@ const Button: React.FC<ButtonProps> = React.forwardRef<
     },
     ref,
   ) => {
+    const { colors } = useTheme()
     return (
       <ButtonInner
         ref={ref}
@@ -114,6 +121,7 @@ const Button: React.FC<ButtonProps> = React.forwardRef<
           },
           className,
         )}
+        colors={colors}
         {...props}
       >
         {isLoading ? (

--- a/src/components/form/checkbox/Checkbox.style.tsx
+++ b/src/components/form/checkbox/Checkbox.style.tsx
@@ -1,8 +1,8 @@
 import type { SystemStyleObject } from '@styled-system/css'
 
-import colors from '../../../styles/modules/colors'
+import { Colors } from '../../../styles/modules/colors'
 
-export const boxStyles: SystemStyleObject = {
+export const boxStyles = (colors?: Colors): SystemStyleObject => ({
   position: 'absolute',
   cursor: 'pointer',
   top: '50%',
@@ -31,12 +31,12 @@ export const boxStyles: SystemStyleObject = {
   },
 
   '.cap-checkbox__input:checked + & ': {
-    bg: 'blue.500',
-    borderColor: 'blue.500',
+    bg: 'primary',
+    borderColor: 'primary',
   },
 
   '.cap-checkbox__input:focus + &': {
-    boxShadow: `0 0 2px 2px ${colors.blue[300]}`,
+    boxShadow: `0 0 2px 2px ${colors?.primaryHover}`,
   },
 
   '.cap-checkbox__input[aria-invalid="true"] + &': {
@@ -66,4 +66,4 @@ export const boxStyles: SystemStyleObject = {
   '.cap-checkbox__input:disabled:checked + &:before': {
     color: 'gray.300',
   },
-}
+})

--- a/src/components/form/checkbox/Checkbox.tsx
+++ b/src/components/form/checkbox/Checkbox.tsx
@@ -1,6 +1,7 @@
 import cn from 'classnames'
 import * as React from 'react'
 
+import { useTheme } from '../../../hooks'
 import { CapUIFontFamily, CapUILineHeight } from '../../../styles'
 import { Box } from '../../box'
 import { PolymorphicBoxProps } from '../../box/Box'
@@ -23,6 +24,7 @@ export const Checkbox: React.FC<CheckboxProps> = React.forwardRef<
   CheckboxProps
 >(({ className, id, children, direction = 'row', ...props }, ref) => {
   const inputProps = useFormControl<HTMLInputElement>(props)
+  const { colors } = useTheme()
 
   return (
     <Flex
@@ -54,7 +56,7 @@ export const Checkbox: React.FC<CheckboxProps> = React.forwardRef<
           ref={ref}
         />
 
-        <Box as="div" className="cap-checkbox__box" sx={boxStyles} />
+        <Box as="div" className="cap-checkbox__box" sx={boxStyles(colors)} />
       </Box>
 
       {typeof children === 'string' ? (

--- a/src/components/form/colorPicker/ColorPicker.tsx
+++ b/src/components/form/colorPicker/ColorPicker.tsx
@@ -111,7 +111,7 @@ export const ColorPicker: React.FC<ColorPickerProps> = ({
               ? 'gray.300'
               : invalid
               ? 'red.500'
-              : 'blue.500',
+              : 'primary',
           },
           '&:focus-within': { bg: disabled ? 'gray.100' : 'white' },
         }}

--- a/src/components/form/hour/HourInput.tsx
+++ b/src/components/form/hour/HourInput.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { components, ControlProps, Props } from 'react-select'
 import ReactSelect from 'react-select'
 
+import { useTheme } from '../../../hooks'
 import { Box } from '../../box'
 import { CapUIIcon, CapUIIconSize, Icon } from '../../icon'
 import { CapInputSize } from '../enums'
@@ -45,6 +46,7 @@ const HourInput = ({
 }: HourInputProps) => {
   const inputProps = useFormControl<HTMLInputElement>(props)
   const [input, setInput] = React.useState(value || '')
+  const { colors } = useTheme()
 
   React.useEffect(() => {
     setInput(value || '')
@@ -58,6 +60,7 @@ const HourInput = ({
       <ReactSelect
         {...inputProps}
         styles={reactSelectStyle(
+          colors,
           inputProps['aria-invalid'],
           inputProps.disabled,
           inputProps.variantSize || CapInputSize.Sm,

--- a/src/components/form/radio/Radio.style.tsx
+++ b/src/components/form/radio/Radio.style.tsx
@@ -1,8 +1,8 @@
 import type { SystemStyleObject } from '@styled-system/css'
 
-import colors from '../../../styles/modules/colors'
+import { Colors } from '../../../styles/modules/colors'
 
-export const boxStyles: SystemStyleObject = {
+export const boxStyles = (colors?: Colors): SystemStyleObject => ({
   position: 'absolute',
   cursor: 'pointer',
   top: '50%',
@@ -17,7 +17,7 @@ export const boxStyles: SystemStyleObject = {
 
   '&:before': {
     content: '""',
-    bg: 'blue.500',
+    bg: 'primary',
     borderRadius: '50%',
     width: '7px',
     height: '7px',
@@ -29,11 +29,11 @@ export const boxStyles: SystemStyleObject = {
   },
 
   '.cap-radio__input:checked + &': {
-    borderColor: 'blue.500',
+    borderColor: 'primary',
   },
 
   '.cap-radio__input:focus + &': {
-    boxShadow: `0 0 2px 2px ${colors.blue[300]}`,
+    boxShadow: `0 0 2px 2px ${colors?.primaryHover}`,
   },
 
   '.cap-radio__input[aria-invalid="true"] + &': {
@@ -63,4 +63,4 @@ export const boxStyles: SystemStyleObject = {
   '.cap-radio__input:disabled:checked + &:before': {
     bg: 'gray.300',
   },
-}
+})

--- a/src/components/form/radio/Radio.tsx
+++ b/src/components/form/radio/Radio.tsx
@@ -1,6 +1,8 @@
+import { SystemStyleObject } from '@styled-system/css'
 import cn from 'classnames'
 import * as React from 'react'
 
+import { useTheme } from '../../../hooks'
 import { CapUIFontFamily, CapUILineHeight } from '../../../styles'
 import { Box } from '../../box'
 import { PolymorphicBoxProps } from '../../box/Box'
@@ -9,7 +11,6 @@ import { Text } from '../../typography'
 import { CapInputSize } from '../enums'
 import { useFormControl } from '../formControl'
 import { boxStyles } from './Radio.style'
-import { SystemStyleObject } from '@styled-system/css'
 
 export interface RadioProps extends PolymorphicBoxProps<'input'> {
   readonly isDisabled?: boolean
@@ -25,6 +26,7 @@ export const Radio: React.FC<RadioProps> = React.forwardRef<
   RadioProps
 >(({ className, id, children, direction = 'row', labelSx, ...props }, ref) => {
   const inputProps = useFormControl<HTMLInputElement>(props)
+  const { colors } = useTheme()
 
   return (
     <Flex
@@ -57,7 +59,7 @@ export const Radio: React.FC<RadioProps> = React.forwardRef<
           ref={ref}
         />
 
-        <Box as="div" className="cap-radio__box" sx={boxStyles} />
+        <Box as="div" className="cap-radio__box" sx={boxStyles(colors)} />
       </Box>
 
       {typeof children === 'string' ? (

--- a/src/components/form/select/AsyncCreatableSelect.tsx
+++ b/src/components/form/select/AsyncCreatableSelect.tsx
@@ -4,6 +4,7 @@ import type { GroupBase } from 'react-select'
 import type { AsyncProps } from 'react-select/async'
 import AsyncCreatable from 'react-select/async-creatable'
 
+import { useTheme } from '../../../hooks'
 import { Box } from '../../box'
 import { CapInputSize } from '../enums'
 import { useFormControl } from '../formControl'
@@ -33,11 +34,13 @@ export function AsyncCreatableSelect<
   ...props
 }: AsyncCreatableSelectProps<Option, IsMulti, Group>) {
   const inputProps = useFormControl<HTMLInputElement>(props)
+  const { colors } = useTheme()
 
   return (
     <Box width={width || '100%'}>
       <AsyncCreatable<Option, IsMulti, Group>
         styles={reactSelectStyle(
+          colors,
           inputProps['aria-invalid'],
           inputProps.disabled,
           inputProps.variantSize,

--- a/src/components/form/select/AsyncSelect.tsx
+++ b/src/components/form/select/AsyncSelect.tsx
@@ -4,6 +4,7 @@ import type { GroupBase } from 'react-select'
 import Async from 'react-select/async'
 import type { AsyncProps } from 'react-select/async'
 
+import { useTheme } from '../../../hooks'
 import { Box } from '../../box'
 import { CapInputSize } from '../enums'
 import { useFormControl } from '../formControl'
@@ -27,11 +28,13 @@ export function AsyncSelect<
   Group extends GroupBase<Option> = GroupBase<Option>
 >({ className, width, ...props }: AsyncSelectProps<Option, IsMulti, Group>) {
   const inputProps = useFormControl<HTMLInputElement>(props)
+  const { colors } = useTheme()
 
   return (
     <Box width={width || '100%'}>
       <Async<Option, IsMulti, Group>
         styles={reactSelectStyle(
+          colors,
           inputProps['aria-invalid'],
           inputProps.disabled,
           inputProps.variantSize,

--- a/src/components/form/select/CreatableSelect.tsx
+++ b/src/components/form/select/CreatableSelect.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import type { GroupBase } from 'react-select'
 import Select from 'react-select/creatable'
 
+import { useTheme } from '../../../hooks'
 import { Box } from '../../box'
 import { useFormControl } from '../formControl'
 import { reactSelectStyle } from '../style'
@@ -20,12 +21,14 @@ export function CreatableSelect<
   Group extends GroupBase<Option> = GroupBase<Option>
 >({ className, width, ...props }: CreatableSelectProps) {
   const inputProps = useFormControl<HTMLInputElement>(props)
+  const { colors } = useTheme()
 
   return (
     <Box width={width || '100%'}>
       {/* @ts-ignore:  https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49673 */}
       <Select
         styles={reactSelectStyle(
+          colors,
           inputProps['aria-invalid'],
           inputProps.disabled,
           inputProps.variantSize,

--- a/src/components/form/select/Select.tsx
+++ b/src/components/form/select/Select.tsx
@@ -7,6 +7,7 @@ import ReactSelect, {
 } from 'react-select'
 import type { GroupBase, Props } from 'react-select'
 
+import { useTheme } from '../../../hooks'
 import { Box } from '../../box'
 import { Icon, CapUIIcon, CapUIIconSize } from '../../icon'
 import { Spinner } from '../../spinner'
@@ -57,7 +58,7 @@ export function Control<
   return (
     <components.Control {...props}>
       {Array.isArray(children) && children[0]}
-      {isLoading && <Spinner mr={2} color="blue.500" />}
+      {isLoading && <Spinner mr={2} color="primary" />}
       {!isLoading && (
         <Icon
           mr={3}
@@ -78,12 +79,14 @@ export function Select<
   Group extends GroupBase<Option> = GroupBase<Option>
 >({ className, width, ...props }: SelectProps) {
   const inputProps = useFormControl<HTMLInputElement>(props)
+  const { colors } = useTheme()
 
   return (
     <Box width={width || '100%'}>
       {/* @ts-ignore:  https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49673 */}
       <ReactSelect
         styles={reactSelectStyle(
+          colors,
           inputProps['aria-invalid'],
           inputProps.disabled,
           inputProps.variantSize,

--- a/src/components/form/style.ts
+++ b/src/components/form/style.ts
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { variant } from 'styled-system'
 
 import { CapUIFontFamily, CapUILineHeight } from '../../styles'
-import colors from '../../styles/modules/colors'
+import { Colors } from '../../styles/modules/colors'
 import { SPACING, ZINDEX } from '../../styles/theme'
 import { FONT_FAMILIES, LINE_HEIGHTS } from '../../styles/theme/typography'
 import { Box } from '../box'
@@ -44,7 +44,7 @@ const styles: SystemStyleObject = {
   },
 
   '&:focus,&[aria-selected="true"],&:active': {
-    borderColor: 'blue.500',
+    borderColor: 'primary',
   },
 
   '&[aria-invalid="true"]': {
@@ -82,7 +82,7 @@ export const focusWithinStyles = (
   },
 
   '&:focus-within': {
-    borderColor: isInvalid ? 'red.500' : 'blue.500',
+    borderColor: isInvalid ? 'red.500' : 'primary',
     bg: 'white',
   },
 })
@@ -92,6 +92,7 @@ export function reactSelectStyle<
   IsMulti extends boolean = false,
   Group extends GroupBase<Option> = GroupBase<Option>
 >(
+  colors: Colors,
   isInvalid: boolean | undefined,
   isDisabled: boolean | undefined,
   variantSize: CapInputSize,
@@ -116,7 +117,7 @@ export function reactSelectStyle<
       borderColor: isInvalid
         ? colors.red['500']
         : isFocused
-        ? colors.blue['500']
+        ? colors.primary
         : colors.gray['300'],
       '&:hover': {
         borderColor: isInvalid ? colors.red['500'] : '',

--- a/src/components/multiStepModal/progressBar/MultiStepModalProgressBar.tsx
+++ b/src/components/multiStepModal/progressBar/MultiStepModalProgressBar.tsx
@@ -52,7 +52,7 @@ const MultiStepModalProgressBar = () => {
               <ItemFillProgressBar
                 key={`item-fill-${step}`}
                 height="100%"
-                bg="blue.500"
+                bg="primary"
                 initial="empty"
                 animate="fill"
                 variants={variants}

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -4,6 +4,7 @@ import { components, ControlProps, GroupBase, SingleValue } from 'react-select'
 import ReactSelect from 'react-select/async'
 import type { AsyncProps } from 'react-select/async'
 
+import { useTheme } from '../../hooks'
 import { Box } from '../box'
 import { CapInputSize, useFormControl } from '../form'
 import { reactSelectStyle } from '../form/style'
@@ -45,7 +46,7 @@ const Control = <
         ml={1}
       />
       {Array.isArray(children) && children[0]}
-      {isLoading && <Spinner mr={1} color="blue.500" />}
+      {isLoading && <Spinner mr={1} color="primary" />}
       {!isLoading && inputValue && (
         <Icon
           mr={1}
@@ -79,6 +80,7 @@ export const Search = <
   loadOptions,
   ...props
 }: SearchProps<Option, IsMulti, Group>) => {
+  const { colors } = useTheme()
   const inputProps = useFormControl<HTMLInputElement>(props)
   const asyncRef = React.useRef(null)
   const [input, setInput] = React.useState(value || '')
@@ -93,6 +95,7 @@ export const Search = <
         {...inputProps}
         ref={asyncRef}
         styles={reactSelectStyle(
+          colors,
           inputProps['aria-invalid'],
           inputProps.disabled,
           inputProps.variantSize || CapInputSize.Sm,

--- a/src/components/switch/Switch.style.ts
+++ b/src/components/switch/Switch.style.ts
@@ -1,13 +1,15 @@
 import type { SystemStyleObject } from '@styled-system/css'
 
-export const sliderStyles: SystemStyleObject = {
+import { Colors } from '../../styles/modules/colors'
+
+export const sliderStyles = (colors?: Colors): SystemStyleObject => ({
   position: 'absolute',
   cursor: 'pointer',
   top: 0,
   left: 0,
   right: 0,
   bottom: 0,
-  bg: 'gray.500',
+  bg: 'neutral-gray.500',
   transition: '0.4s',
   borderRadius: '10px',
 
@@ -25,7 +27,11 @@ export const sliderStyles: SystemStyleObject = {
   },
 
   '.cap-switch__input:checked + & ': {
-    bg: 'blue.500',
+    bg: 'primary',
+  },
+
+  '.cap-switch__input:focus + &': {
+    boxShadow: `0 0 2px 2px ${colors?.primaryHover}`,
   },
 
   '.cap-switch__input:disabled + &': {
@@ -35,4 +41,4 @@ export const sliderStyles: SystemStyleObject = {
   '.cap-switch__input:checked + &:before': {
     transform: 'translateX(16px)',
   },
-}
+})

--- a/src/components/switch/Switch.tsx
+++ b/src/components/switch/Switch.tsx
@@ -1,6 +1,7 @@
 import cn from 'classnames'
 import * as React from 'react'
 
+import { useTheme } from '../../hooks'
 import { CapUILineHeight } from '../../styles'
 import { Box, PolymorphicBoxProps } from '../box/Box'
 import { useFormControl } from '../form'
@@ -22,7 +23,7 @@ export const Switch: React.FC<SwitchProps> = React.forwardRef<
   SwitchProps
 >(({ className, children, id, direction = 'row', ...props }, ref) => {
   const inputProps = useFormControl<HTMLInputElement>(props)
-
+  const { colors } = useTheme()
   return (
     <Flex
       display="inline-flex"
@@ -51,7 +52,11 @@ export const Switch: React.FC<SwitchProps> = React.forwardRef<
           ref={ref}
         />
 
-        <Box as="div" className="cap-switch__slider" sx={sliderStyles} />
+        <Box
+          as="div"
+          className="cap-switch__slider"
+          sx={sliderStyles(colors)}
+        />
       </Box>
 
       {typeof children === 'string' ? (

--- a/src/components/table/td/Td.tsx
+++ b/src/components/table/td/Td.tsx
@@ -16,7 +16,7 @@ export interface TdProps extends BoxPropsOf<'td'> {
 const styles = {
   a: {
     '&:hover': {
-      color: 'blue.500',
+      color: 'primary',
     },
   },
 }

--- a/src/styles/modules/colors.ts
+++ b/src/styles/modules/colors.ts
@@ -10,7 +10,15 @@ export type BaseColorsName =
   | 'blue'
   | 'aqua'
 
-type RootThemeColorsValues = 'transparent' | 'current' | 'black' | 'white'
+type RootThemeColorsValues =
+  | 'transparent'
+  | 'current'
+  | 'black'
+  | 'white'
+  | 'primary'
+  | 'primaryLabel'
+  | 'primaryHover'
+  | 'primaryLabelHover'
 
 type BaseColors = {
   [key in BaseColorsName]: {
@@ -29,6 +37,11 @@ const colors: Colors = {
 
   black: '#000',
   white: '#fff',
+
+  primary: '#1A88FF',
+  primaryLabel: '#FAFCFF',
+  primaryHover: '#0051A8',
+  primaryLabelHover: '#FAFCFF',
 
   gray: {
     '100': '#F7F7F8',

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,0 +1,19 @@
+export const newShade = (hexColor: string | null, magnitude: number) => {
+  if (!hexColor) return ''
+  hexColor = hexColor.replace(`#`, ``)
+  if (hexColor.length === 6) {
+    const decimalColor = parseInt(hexColor, 16)
+    let r = (decimalColor >> 16) + magnitude
+    r > 255 && (r = 255)
+    r < 0 && (r = 0)
+    let g = (decimalColor & 0x0000ff) + magnitude
+    g > 255 && (g = 255)
+    g < 0 && (g = 0)
+    let b = ((decimalColor >> 8) & 0x00ff) + magnitude
+    b > 255 && (b = 255)
+    b < 0 && (b = 0)
+    return `#${(g | (b << 8) | (r << 16)).toString(16)}`
+  } else {
+    return hexColor
+  }
+}


### PR DESCRIPTION
#### :tophat: What? Why?
<!-- Describe your changes -->
Pour rendre le DS futur proof, permettre de + facilement y injecter des couleurs.

Historiquement, le DS a été pensé sur une palette de couleur précise -> [Ici ](https://ds.cap-collectif.com/?path=/story/colors--page)

Pour le back office, on est globalement parti sur du bleu, avec du `blue.500` en couleur primaire, qu'on retrouve un peu partout en dur dans le code. Par exemple, le code de style du `<Button />`, actuellement : 

<img width="438" alt="Capture d’écran 2023-09-05 à 13 39 45" src="https://github.com/cap-collectif/ui/assets/21263655/fa566583-fc9d-4593-af5e-d020828db34b">

C'est pas optimal, ça laisse aucune possibilité de personnalisation. En plus de ça, pour adapter le DS côté client, on peut pas se limiter à une palette de couleur, puisque certains (la majorité) voudront une charte graphique qui leur est spécifique. J'ai donc ajouté, dans le fichier de couleurs, des valeurs supplémentaires, pour tester un fonctionnement différent : 

<img width="242" alt="Capture d’écran 2023-09-05 à 13 44 20" src="https://github.com/cap-collectif/ui/assets/21263655/1f077a03-10e5-44ac-b76f-cb640c28abb2">

Par défaut, ces valeurs reprennent celles autour du `blue.500`, mais ça me permet, dans le code du bouton vu plus haut par exemple, d'avoir ça : 

<img width="559" alt="Capture d’écran 2023-09-05 à 13 45 34" src="https://github.com/cap-collectif/ui/assets/21263655/b32c34a0-4326-407a-a3d5-207faa5f5cc0">

Du coup, lorsque l'on injecte le thème, on a juste à remplacer ces couleurs si besoin, et ça donne un bouton totalement personnalisable : 

<img width="201" alt="Capture d’écran 2023-09-05 à 13 47 32" src="https://github.com/cap-collectif/ui/assets/21263655/99a6d1d4-a755-474c-a105-ec945e6b2562">


J'ai modifié le style de la plupart des versions primaires des composants existants -> [Exemple de rendu ici (couleurs modifiables à la volée dans les controls) ](https://color-customization--60ca00d41db7ba003be931d8.chromatic.com/?path=/story/withcustomtheme--default)


Techniquement, ça fonctionne, maintenant les questions que ça soulève : 

- Quid des teintes de bleues différentes, sur les spotIcons où l'uploader par exemple. Actuellement en dur, on a pas assez de couleur dans l'actuelle [page apparence ](https://demo2.cap-collectif.com/admin/settings/settings.appearance/list) de la plateforme pour injecter tant de couleurs différentes. 
**Solutions temporaires proposées : 
1 . Laisser les compo tel quel dans un premier temps, je sais même pas s'ils seront tous utilisés côté frontend. 
2 . Créer les teintes dans le code à partir de la couleur primaire. On peut facilement créer des utiliaires lighten() ou darken(), ce serait chouette !
3 . Redesign plus simpliste de certains compos.**

- Quid des couleurs autre que la couleur primaire ? Les couleurs `warning` , `success` , `danger` , qui sont actuellement dans la palette de couleurs, en jaune, vert et rouge. On peut les laisser comme ça dans un premier temps, à voir ce qu'on fait 

- La page apparence. À terme ce serait cool de la refaire, on pourrait avoir une preview live du look des boutons, un truc assez moderne, je crois que Sylvain a déjà commencé à travailler dessus.

Voilà pour moi, dans tous les cas le fonctionnement existant n'est pas cassé, la palette de couleur est toujours utilisable, et comme j'ai laissé le `blue.500` en primary par défaut, on prend pas de risque de casser le BO. Il va donc falloir dans un futur proche arbitrer les couleurs à utiliser, et on aura un front 100% moderne 100% customizable (fin on aura de quoi le faire, c'est différent)

#### :pushpin: Related Issues
<!-- What existing **issue(s)** does the pull request solve? -->
Le frontend catastrophique 
#### :clipboard: Technical Specification
<!-- Describe how you plan to solve the problem
- [x] Subtask 1
- [ ] Subtask 2
-->

#### :art: Chromatic links
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=379)
[Storybook](https://color-customization--60ca00d41db7ba003be931d8.chromatic.com) 

#### :camera_flash: Screenshots
<!-- Screenshots if appropriate -->