### PR TITLE
Fix InfoMessage.Title to include React Element

### DIFF
--- a/src/components/infoMessage/InfoMessage.stories.tsx
+++ b/src/components/infoMessage/InfoMessage.stories.tsx
@@ -1,9 +1,11 @@
 import { Meta, Story } from '@storybook/react'
 import React from 'react'
 
+import { Flex } from '../layout'
 import { Text } from '../typography'
 import { InfoMessage, InfoMessageProps } from './'
 import mdx from './InfoMessage.mdx'
+import { Tag } from '../tag';
 
 const meta: Meta<InfoMessageProps> = {
   title: 'Library/InfoMessage',
@@ -33,5 +35,22 @@ export const Default: Story<InfoMessageProps> = args => (
 export const WithIcon: Story<InfoMessageProps> = args => (
   <InfoMessage {...args}>
     <InfoMessage.Title withIcon>Ceci est un titre</InfoMessage.Title>
+  </InfoMessage>
+)
+
+export const WithHTMLInTitle: Story<InfoMessageProps> = args => (
+  <InfoMessage {...args}>
+    <InfoMessage.Title gap={3}>
+      <Tag variantColor="blue">
+        <Tag.Label>Bonjour</Tag.Label>
+      </Tag>
+      <Tag variantColor="red">
+        <Tag.Label>CouCou</Tag.Label>
+      </Tag>
+    </InfoMessage.Title>
+    <InfoMessage.Content>
+      <Text>Hello</Text>
+      <Text>World</Text>
+    </InfoMessage.Content>
   </InfoMessage>
 )

--- a/src/components/infoMessage/InfoMessage.stories.tsx
+++ b/src/components/infoMessage/InfoMessage.stories.tsx
@@ -1,7 +1,6 @@
 import { Meta, Story } from '@storybook/react'
 import React from 'react'
 
-import { Flex } from '../layout'
 import { Text } from '../typography'
 import { InfoMessage, InfoMessageProps } from './'
 import mdx from './InfoMessage.mdx'

--- a/src/components/infoMessage/title/InfoMessageTitle.tsx
+++ b/src/components/infoMessage/title/InfoMessageTitle.tsx
@@ -16,7 +16,7 @@ type VariantIcon = {
 }
 
 type InfoMessageTitleProps = FlexProps & {
-  readonly children: string
+  readonly children: string | React.ReactNodeArray | React.ReactNode
   readonly withIcon?: boolean
 }
 
@@ -83,9 +83,13 @@ export const InfoMessageTitle = ({
       {...props}
     >
       {withIcon && getIcon(variant)}
-      <Text color={getColor(variant)} fontSize={1} lineHeight="sm">
-        {children}
-      </Text>
+      {typeof children === 'string' ? (
+        <Text color={getColor(variant)} fontSize={1} lineHeight="sm">
+          {children}
+        </Text>
+      ) : (
+        children
+      )}
     </Flex>
   )
 }


### PR DESCRIPTION
#### :tophat: What? Why?
<!-- Describe your changes -->

Add React.Element type to  InfoMessage.Title for when we use FormattedHTMLMessage


#### :pushpin: Related Issues
<!-- What existing **issue(s)** does the pull request solve? -->
#368 
#### :clipboard: Technical Specification
<!-- Describe how you plan to solve the problem
- [x] Subtask 1
- [ ] Subtask 2
-->

#### :art: Chromatic links
<!--
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=<PR number>)
[Storybook](https://<branch>--60ca00d41db7ba003be931d8.chromatic.com) 
-->
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=384)
[Storybook](https://368-infomessage-title--60ca00d41db7ba003be931d8.chromatic.com) 