### PR TITLE
1.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,18 @@ To better understand the changelog, here are some legends we use:
 - 🛠 Refactor
 - 💄 Style
 
+## 1.8.4
+
+`2023-11-09`
+
+- 🛠 Pass ref on `Search` component [#394](https://github.com/cap-collectif/ui/pull/394)
+
 ## 1.8.3
 
 `2023-10-10`
 
 - 💄 Fix `TabButton` Z-index [#392](https://github.com/cap-collectif/ui/pull/392)
-- 
+
 ## 1.8.2
 
 `2023-09-27`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.8.3",
+  "version": "1.8.4",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -67,7 +67,7 @@ const Control = <
   )
 }
 
-export const Search = <
+export const SearchWithRef = <
   Option,
   IsMulti extends false = false,
   Group extends GroupBase<Option> = GroupBase<Option>
@@ -129,8 +129,8 @@ export const Search = <
   )
 }
 
-const SearchWithRef = React.forwardRef(Search)
+export const Search = React.forwardRef(SearchWithRef)
 
-SearchWithRef.displayName = 'Search'
+Search.displayName = 'Search'
 
-export default SearchWithRef
+export default Search


### PR DESCRIPTION
## 1.8.4

`2023-11-09`

- 🛠 Pass ref on `Search` component [#394](https://github.com/cap-collectif/ui/pull/394)