### PR TITLE
MultiStepBody offset 40%

### DIFF
--- a/src/components/multiStepModal/MultiStepModal.stories.tsx
+++ b/src/components/multiStepModal/MultiStepModal.stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 
 import { Box } from '../box'
 import { Button } from '../button'
-import { FormLabel, Input } from '../form'
+import { CodeInput, FormLabel, Input } from '../form'
 import { CapUIIcon, CapUIIconSize, Icon } from '../icon'
 import { Flex } from '../layout'
 import { CapUIModalSize } from '../modal'
@@ -234,6 +234,7 @@ const Step = ({
   onClose,
   firstStep,
   lastStep,
+  input,
 }: {
   title: string
   info: string
@@ -242,6 +243,7 @@ const Step = ({
   onClose: () => void
   firstStep?: boolean
   lastStep?: boolean
+  input?: React.ReactNode
 }) => {
   const { goToNextStep, goToPreviousStep } = useMultiStepModal()
 
@@ -305,7 +307,7 @@ const Step = ({
           {lastStep ? null : (
             <Box width="100%" mb={4}>
               <FormLabel label={label || ''} mb={1} />
-              <Input placeholder={placeholder} />
+              {input ? input : <Input placeholder={placeholder} />}
             </Box>
           )}
           <Button
@@ -357,6 +359,18 @@ export const FullScreen: Story<MultiStepModalProps> = () => {
           info="Il sera visible sur votre profil et sur vos participations"
           placeholder="ex : John.D"
           label="Pseudonyme"
+        />
+        <Step
+          onClose={() => setShow(false)}
+          title="Renseignez votre code"
+          info="Renseignez votre code"
+          placeholder="Code"
+          label="Code"
+          input={
+            <Flex justifyContent="center">
+              <CodeInput onComplete={() => {}} />
+            </Flex>
+          }
         />
         <Step
           onClose={() => setShow(false)}

--- a/src/components/multiStepModal/body/MultiStepModalBody.tsx
+++ b/src/components/multiStepModal/body/MultiStepModalBody.tsx
@@ -11,7 +11,7 @@ export type MultiStepModalBodyProps = ModalBodyProps
 
 const variants = {
   enter: (direction: DIRECTION) => ({
-    x: direction === DIRECTION.LEFT ? '-50%' : '50%',
+    x: direction === DIRECTION.LEFT ? '-40%' : '40%', // we set 40% because for some reason 50% is shifting the layout in chrome
     opacity: 0,
   }),
   center: {


### PR DESCRIPTION
#### :tophat: What? Why?
<!-- Describe your changes -->
on set l'offset de la transition à 40%, en laissant à 50% le layout shift sur chrome mais pas sur les firefox/safari
j'ajoute un cas dans la story avec le code input

#### :pushpin: Related Issues
<!-- What existing **issue(s)** does the pull request solve? -->

#### :clipboard: Technical Specification
<!-- Describe how you plan to solve the problem
- [x] Subtask 1
- [ ] Subtask 2
-->

#### :art: Chromatic links

[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=430)
[Storybook](https://multistep-modal-body-disable-transition--60ca00d41db7ba003be931d8.chromatic.com) 


#### :camera_flash: Screenshots
<!-- Screenshots if appropriate -->