### PR TITLE
fix(toast): onClose, toast hidden still present in DOM

### DIFF
--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -31,6 +31,7 @@ export interface ToastProps {
   readonly variant: 'info' | 'success' | 'danger' | 'warning' | 'loading'
   readonly content: React.ReactNode
   readonly onClose?: () => void
+  readonly setToast?: (value: null) => void
 }
 
 type StyledProps = {
@@ -108,6 +109,7 @@ export const Toast: React.FC<ToastProps> = ({
   content,
   id,
   onClose,
+  setToast,
   position,
   ...props
 }) => {
@@ -116,6 +118,9 @@ export const Toast: React.FC<ToastProps> = ({
 
   const handleClose = () => {
     setShow(false)
+    if (setToast) {
+      setToast(null)
+    }
     if (onClose) {
       onClose()
     }

--- a/src/components/toast/ToastContainer.tsx
+++ b/src/components/toast/ToastContainer.tsx
@@ -71,7 +71,7 @@ const ToastContainer = () => {
           transition={LAYOUT_TRANSITION_SPRING}
           aria-roledescription={getAriaRole(toast.variant)}
         >
-          <Toast {...toast} />
+          <Toast setToast={setToast} {...toast} />
         </ToastWrapper>
       )}
     </Box>


### PR DESCRIPTION
#### :tophat: What? Why?
<!-- Describe your changes -->

#### :pushpin: Related Issues
[17198](https://github.com/cap-collectif/platform/issues/17198)

#### :clipboard: Technical Specification
- [x] Pass setToast and set it to null when "close" icon is clicked

#### :art: Chromatic links
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=436)
[Storybook](https://fix-non-disappearing-toast--60ca00d41db7ba003be931d8.chromatic.com) 

#### :camera_flash: Screenshots
<!-- Screenshots if appropriate -->