### PR TITLE
fix(toast): events not working when several instances of ToastContainer exist

### DIFF
--- a/src/components/toast/ToastContainer.tsx
+++ b/src/components/toast/ToastContainer.tsx
@@ -26,12 +26,16 @@ const ToastContainer = () => {
   const visible = toast !== null
 
   useEffect(() => {
-    Emitter.on(UIEvents.ToastShow, (newToast: ToastProps) => {
-      setToast(newToast)
-    })
-    Emitter.on(UIEvents.ToastClear, () => {
-      setToast(null)
-    })
+    // We use several <ToastContainer> throughout the app
+    // We check if a Container already exists before creating a new one that could interfere with others, preventing events from working
+    if (Emitter.listenerCount(UIEvents.ToastShow) === 0) {      
+      Emitter.on(UIEvents.ToastShow, (newToast: ToastProps) => {
+        setToast(newToast)
+      })
+      Emitter.on(UIEvents.ToastClear, () => {
+        setToast(null)
+      })
+    }
 
     return () => {
       Emitter.removeAllListeners(UIEvents.ToastShow)


### PR DESCRIPTION
#### :tophat: What? Why?
Dans platform, on utilise <ToastContainer> à plusieurs endroits.
Pour fermer un toast, on devait appeler la fonction onClose autant de fois qu'il existe de <ToastContainer>

#### :pushpin: Related Issues
[17198](https://github.com/cap-collectif/platform/issues/17198)

#### :clipboard: Technical Specification
- [x] ajouter une condition qui vérifie s'il existe déjà ou non des listeners avant de les créer

#### :art: Chromatic links
<!--
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=<PR number>)
[Storybook](https://<branch>--60ca00d41db7ba003be931d8.chromatic.com) 
-->

#### :camera_flash: Screenshots
<!-- Screenshots if appropriate -->