### PR TITLE
1.10.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ To better understand the changelog, here are some legends we use:
 - 🛠 Refactor
 - 💄 Style
 
+## 1.10.11
+
+`2024-07-22`
+
+- 🐛 Fix crash when primary color absent [#443](https://github.com/cap-collectif/ui/pull/443)
+
 ## 1.10.10
 
 `2024-07-16`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.10",
+  "version": "1.10.11",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## 1.10.11

`2024-07-22`

- 🐛 Fix crash when primary color absent [#443](https://github.com/cap-collectif/ui/pull/443)