### PR TITLE
refactor: replace hour input with html native input type="time"

### DIFF
--- a/src/components/form/hour/HourInput.stories.tsx
+++ b/src/components/form/hour/HourInput.stories.tsx
@@ -39,23 +39,20 @@ const meta: Meta = {
 export default meta
 
 export const Default: Story<Args> = args => {
-  const [value, onChange] = React.useState<string | null>(null)
-  return <HourInput {...args} value={value} onChange={onChange} />
+  return <HourInput {...args} />
 }
 
 export const Disabled: Story<Args> = args => {
-  const [value, onChange] = React.useState<string | null>(null)
-  return <HourInput {...args} value={value} onChange={onChange} />
+  return <HourInput {...args} />
 }
 Disabled.args = {
   isDisabled: true,
 }
 
 export const WithError: Story<Args> = ({ errorMessage, ...args }) => {
-  const [value, onChange] = React.useState<string | null>(null)
   return (
     <FormControl {...args}>
-      <HourInput {...args} value={value} onChange={onChange} />
+      <HourInput {...args} />
       <FormErrorMessage>{errorMessage}</FormErrorMessage>
     </FormControl>
   )

--- a/src/components/form/hour/HourInput.tsx
+++ b/src/components/form/hour/HourInput.tsx
@@ -38,10 +38,6 @@ const HourInput = React.forwardRef<HTMLInputElement, HourInputProps>(
     const [value, setValue] = React.useState(defaultValue || '')
     const { colors } = useTheme()
 
-    React.useEffect(() => {
-      setValue(defaultValue || '')
-    }, [defaultValue])
-
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       const newValue = event.target.value
       setValue(newValue)

--- a/src/components/form/hour/HourInput.tsx
+++ b/src/components/form/hour/HourInput.tsx
@@ -35,16 +35,16 @@ const HourInput = React.forwardRef<HTMLInputElement, HourInputProps>(
     ref,
   ) => {
     const inputProps = useFormControl<HTMLInputElement>(props)
-    const [input, setInput] = React.useState(defaultValue || '')
+    const [value, setValue] = React.useState(defaultValue || '')
     const { colors } = useTheme()
 
     React.useEffect(() => {
-      setInput(defaultValue || '')
+      setValue(defaultValue || '')
     }, [defaultValue])
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       const newValue = event.target.value
-      setInput(newValue)
+      setValue(newValue)
       if (onChange) onChange(newValue)
     }
 
@@ -53,7 +53,7 @@ const HourInput = React.forwardRef<HTMLInputElement, HourInputProps>(
         <Input
           {...inputProps}
           type="time"
-          value={input}
+          value={value}
           onChange={handleChange}
           placeholder={placeholder}
           disabled={inputProps.disabled}

--- a/src/components/form/hour/HourInput.tsx
+++ b/src/components/form/hour/HourInput.tsx
@@ -17,13 +17,13 @@ export interface HourInputProps {
   readonly variantSize?: CapInputSize
   readonly width?: string | number
   readonly onChange?: (value: string) => void
-  readonly value?: string | null
+  readonly defaultValue?: string | null
 }
 
 const HourInput = React.forwardRef<HTMLInputElement, HourInputProps>(
   (
     {
-      value,
+      defaultValue,
       onChange,
       id = 'cap-hour-input-id',
       className,
@@ -35,12 +35,12 @@ const HourInput = React.forwardRef<HTMLInputElement, HourInputProps>(
     ref,
   ) => {
     const inputProps = useFormControl<HTMLInputElement>(props)
-    const [input, setInput] = React.useState(value || '')
+    const [input, setInput] = React.useState(defaultValue || '')
     const { colors } = useTheme()
 
     React.useEffect(() => {
-      setInput(value || '')
-    }, [value])
+      setInput(defaultValue || '')
+    }, [defaultValue])
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       const newValue = event.target.value

--- a/src/components/form/hour/HourInput.tsx
+++ b/src/components/form/hour/HourInput.tsx
@@ -1,18 +1,16 @@
-import classNames from 'classnames'
+import cn from 'classnames'
 import React from 'react'
-import { components, ControlProps, Props } from 'react-select'
-import ReactSelect from 'react-select'
 
 import { useTheme } from '../../../hooks'
 import { Box } from '../../box'
-import { CapUIIcon, CapUIIconSize, Icon } from '../../icon'
 import { CapInputSize } from '../enums'
 import { useFormControl } from '../formControl'
-import { reactSelectStyle } from '../style'
-import options from './HourInput.utils'
+import { Input } from '../input'
 
-export interface HourInputProps
-  extends Omit<Props, 'onChange' | 'isMulti' | 'value'> {
+export interface HourInputProps {
+  readonly id?: string
+  readonly className?: string
+  readonly placeholder?: string
   readonly isDisabled?: boolean
   readonly disabled?: string
   readonly isInvalid?: boolean
@@ -22,78 +20,60 @@ export interface HourInputProps
   readonly value?: string | null
 }
 
-const Control = ({ children, ...props }: ControlProps) => (
-  <components.Control {...props}>
-    {Array.isArray(children) && children[0]}
-    <Icon
-      mr={1}
-      name={CapUIIcon.Clock}
-      size={CapUIIconSize.Md}
-      color="gray.700"
-    />
-  </components.Control>
+const HourInput = React.forwardRef<HTMLInputElement, HourInputProps>(
+  (
+    {
+      value,
+      onChange,
+      id = 'cap-hour-input-id',
+      className,
+      placeholder = '00:00',
+      width,
+      disabled,
+      ...props
+    },
+    ref,
+  ) => {
+    const inputProps = useFormControl<HTMLInputElement>(props)
+    const [input, setInput] = React.useState(value || '')
+    const { colors } = useTheme()
+
+    React.useEffect(() => {
+      setInput(value || '')
+    }, [value])
+
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = event.target.value
+      setInput(newValue)
+      if (onChange) onChange(newValue)
+    }
+
+    return (
+      <Box width={width || '92px'}>
+        <Input
+          {...inputProps}
+          type="time"
+          value={input}
+          onChange={handleChange}
+          placeholder={placeholder}
+          disabled={inputProps.disabled}
+          aria-invalid={inputProps['aria-invalid']}
+          className={cn('cap-hour-input', className)}
+          ref={ref}
+          style={{
+            width: '100%',
+            height: props.variantSize === 'sm' ? '34px' : '42px',
+            padding: '0.5rem',
+            borderColor: inputProps['aria-invalid']
+              ? colors.red[500]
+              : colors.gray[300],
+          }}
+        />
+      </Box>
+    )
+  },
 )
 
-const HourInput = ({
-  value,
-  onChange,
-  id = 'cap-Hour-input-id',
-  className,
-  placeholder = '00:00',
-  width,
-  disabled,
-  ...props
-}: HourInputProps) => {
-  const inputProps = useFormControl<HTMLInputElement>(props)
-  const [input, setInput] = React.useState(value || '')
-  const { colors } = useTheme()
-
-  React.useEffect(() => {
-    setInput(value || '')
-  }, [value])
-
-  return (
-    <Box
-      width={width || '92px'}
-      sx={{ input: { opacity: value ? '1 !important' : 0 } }}
-    >
-      <ReactSelect
-        {...inputProps}
-        styles={reactSelectStyle(
-          colors,
-          inputProps['aria-invalid'],
-          inputProps.disabled,
-          inputProps.variantSize || CapInputSize.Sm,
-        )}
-        inputValue={input || ''}
-        value={!value ? null : { label: value || '', value }}
-        onInputChange={(newValue, action) => {
-          if (action.action === 'input-change') {
-            setInput(newValue)
-            if (onChange) onChange(newValue)
-          }
-        }}
-        // @ts-ignore newValue is supposed to be generic (unknown)
-        onChange={(newValue: { label: string; value: string }) => {
-          if (newValue) {
-            setInput(newValue.value)
-            if (onChange && newValue) onChange(newValue.value)
-          }
-        }}
-        className={classNames('cap-hour-input', className)}
-        classNamePrefix="cap-hour-input"
-        isDisabled={inputProps.disabled}
-        aria-invalid={inputProps['aria-invalid']}
-        components={{ Control }}
-        options={options}
-        maxMenuHeight={210}
-        menuPortalTarget={document?.body}
-        placeholder={placeholder}
-        noOptionsMessage={() => null}
-        {...props}
-      />
-    </Box>
-  )
-}
+HourInput.displayName = 'HourInput'
 
 export default HourInput

--- a/src/components/form/inputGroup/InputGroup.stories.tsx
+++ b/src/components/form/inputGroup/InputGroup.stories.tsx
@@ -39,10 +39,9 @@ const colourOptions = [
 ]
 
 export const Default: Story<InputGroupProps> = args => {
-  const [
-    dateRangeExample,
-    setDateRangeExample,
-  ] = React.useState<DateRangeValueType>({
+  const [dateRangeExample, setDateRangeExample] = React.useState<
+    DateRangeValueType
+  >({
     startDate: null,
     endDate: null,
   })
@@ -180,10 +179,9 @@ export const Default: Story<InputGroupProps> = args => {
   )
 }
 export const WithError: Story<InputGroupProps> = args => {
-  const [
-    dateRangeExample,
-    setDateRangeExample,
-  ] = React.useState<DateRangeValueType>({
+  const [dateRangeExample, setDateRangeExample] = React.useState<
+    DateRangeValueType
+  >({
     startDate: null,
     endDate: null,
   })
@@ -288,6 +286,23 @@ export const WithError: Story<InputGroupProps> = args => {
         </FormControl>
         <FormControl isInvalid {...args}>
           <Input placeholder="Placeholder..." />
+          <FormErrorMessage>Error Info</FormErrorMessage>
+        </FormControl>
+      </InputGroup>
+      <InputGroup>
+        <FormControl isInvalid {...args}>
+          <DateInput
+            value={dateExample}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setDateExample(e.target.value)
+            }
+          />
+        </FormControl>
+        <FormControl isInvalid {...args}>
+          <HourInput
+            placeholder="Placeholder..."
+            variantSize={CapInputSize.Sm}
+          />
           <FormErrorMessage>Error Info</FormErrorMessage>
         </FormControl>
       </InputGroup>

--- a/src/components/form/inputGroup/InputGroup.stories.tsx
+++ b/src/components/form/inputGroup/InputGroup.stories.tsx
@@ -290,6 +290,7 @@ export const WithError: Story<InputGroupProps> = args => {
         </FormControl>
       </InputGroup>
       <InputGroup>
+        <FormLabel label="Label" />
         <FormControl isInvalid {...args}>
           <DateInput
             value={dateExample}
@@ -297,6 +298,7 @@ export const WithError: Story<InputGroupProps> = args => {
               setDateExample(e.target.value)
             }
           />
+          <FormErrorMessage>Error Info</FormErrorMessage>
         </FormControl>
         <FormControl isInvalid {...args}>
           <HourInput


### PR DESCRIPTION
#### :tophat: What? Why?
Un bug sur l'input type heure a été repéré sur une branche de `platform`.
Plutôt que de le corriger et maintenir notre custom input type="dateHour", on met à jour pour utiliser le composant html natif `<input type="time" />`

#### :pushpin: Related Issues
https://github.com/cap-collectif/ui/issues/446

#### :clipboard: Technical Specification
- [x] remplacer l'input custom fait avec un ReactSelect par un input type="time" natif
- [x] ajouter ce composant à la story "erreur" (il manquait)

#### :art: Chromatic links
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=447)
[Storybook](https://446-refactor-hour-input--60ca00d41db7ba003be931d8.chromatic.com) 

#### :camera_flash: Screenshots
AVANT :
<img width="285" alt="Screenshot 2024-08-01 at 12 02 30" src="https://github.com/user-attachments/assets/761a8ff3-b2c4-45f9-a57d-293be1e6df31">

<img width="316" alt="Screenshot 2024-08-01 at 12 03 34" src="https://github.com/user-attachments/assets/31ce1af6-0559-430c-8d69-198df434e45a">


APRES : 
<img width="262" alt="Screenshot 2024-08-01 at 12 02 57" src="https://github.com/user-attachments/assets/9a603e59-4f24-426c-b8aa-262133713633">

<img width="309" alt="Screenshot 2024-08-01 at 12 03 11" src="https://github.com/user-attachments/assets/5658976d-d604-455c-b020-0b8321f7ffef">
