### PR TITLE
fix(accessibility): make delete text icon a button and add a delete icon label prop, defaulting to french

### DIFF
--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -33,7 +33,7 @@ export interface SearchProps<
   readonly onChange?: (value: string) => void
   readonly onSelect?: (value: Option) => void
   readonly value?: string
-  readonly inputTitle?:string
+  readonly inputTitle?: string
 }
 
 const Control = <
@@ -43,8 +43,10 @@ const Control = <
 >({
   children,
   ...props
-}: ControlProps<Option, IsMulti, Group>) => {
+}: ControlProps<Option, IsMulti, Group> & { deleteButtonAriaLabel?: string })  => {
   const { isLoading, inputValue, onInputChange } = props.selectProps
+  const { deleteButtonAriaLabel } = props
+  
   return (
     <components.Control {...props}>
       <Icon
@@ -56,20 +58,25 @@ const Control = <
       {Array.isArray(children) && children[0]}
       {isLoading && <Spinner mr={1} color="primary.500" />}
       {!isLoading && inputValue && (
-        <Icon
+        <Box as={'button'} type="button"
           mr={1}
           style={{ cursor: 'pointer' }}
-          name={CapUIIcon.Cross}
-          size={CapUIIconSize.Md}
-          color="gray.700"
-          _hover={{ color: 'red.500' }}
           onClick={() => {
             onInputChange('', {
               action: 'input-change',
               prevInputValue: inputValue,
             })
           }}
-        />
+          >
+          <Icon
+            name={CapUIIcon.Cross}
+            size={CapUIIconSize.Md}
+            color="gray.700"
+            _hover={{ color: 'red.500' }}
+            role="img"
+            aria-label={deleteButtonAriaLabel || "Supprimer la saisie"}
+          />
+        </Box>
       )}
     </components.Control>
   )

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -67,14 +67,15 @@ const Control = <
               prevInputValue: inputValue,
             })
           }}
+            aria-label={deleteButtonAriaLabel || "Supprimer la saisie"}
           >
           <Icon
             name={CapUIIcon.Cross}
             size={CapUIIconSize.Md}
             color="gray.700"
             _hover={{ color: 'red.500' }}
-            role="img"
-            aria-label={deleteButtonAriaLabel || "Supprimer la saisie"}
+            aria-hidden
+            focusable={false}
           />
         </Box>
       )}


### PR DESCRIPTION
#### :tophat: What? Why?
Demande accessibilité IDF
Pas possible d'embarquer `Intl`, donc j'ai ajouté une prop, dont la valeur par défaut est le texte proposé par IDF, à savoir "Supprimer la saisie".
Ajout des roles aria et changement du svg cliquable en un bouton type button également pour l'accessibilité

#### :pushpin: Related Issues
https://github.com/cap-collectif/platform/issues/17279 

#### :clipboard: Technical Specification
- [x] changement du `<Icon/>` en un `<Box as={"button"}/>`
- [x] ajout des attributs aria demandés

#### :art: Chromatic links

[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=449)
[Storybook](https://17279-idf-search-button--60ca00d41db7ba003be931d8.chromatic.com) 


#### :camera_flash: Screenshots
<!-- Screenshots if appropriate -->