### PR TITLE
fix: remove tab content if it's empty

### DIFF
--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -220,3 +220,38 @@ export const withDisabledTab: Story<TabsProps> = args => {
     </Flex>
   )
 }
+
+
+export const withEmptyContent: Story<TabsProps> = args => {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  // const [value, setValue] = React.useState('')
+// 
+  return (
+    <Flex
+      direction="column"
+      justifyContent="flexStart"
+      alignItems="flexStart"
+      height="800px"
+    >
+      <Tabs {...args}>
+        <Tabs.ButtonList ariaLabel="Tabs example">
+          <Tabs.Button id="tab1">I am empty</Tabs.Button>
+          <Tabs.Button id="tab2">I have content</Tabs.Button>
+          <Tabs.Button id="tab3">I am empty, too!</Tabs.Button>
+          
+        </Tabs.ButtonList>
+        <Tabs.PanelList>
+          <Tabs.Panel >
+          </Tabs.Panel>
+
+          <Tabs.Panel>
+            I'm panel content
+          </Tabs.Panel>
+
+          <Tabs.Panel >  
+          </Tabs.Panel>
+        </Tabs.PanelList>
+      </Tabs>
+    </Flex>
+  )
+}

--- a/src/components/Tabs/button/TabsButton.tsx
+++ b/src/components/Tabs/button/TabsButton.tsx
@@ -28,6 +28,12 @@ const TabsButton: React.FC<TabsButtonProps> = ({
     }
   }, [])
 
+  const currentTab = tabs.currentId
+  const currentTabPanel = tabs.panels.find(
+    panel => panel.groupId === currentTab,
+  )
+  const currentTabIsEmpty = currentTabPanel?.ref.current?.lastChild === null
+
   return (
     <BaseTab
       as={Radio}
@@ -47,6 +53,8 @@ const TabsButton: React.FC<TabsButtonProps> = ({
           id === tabs.currentId ? CapUIRadius.Accordion : CapUIRadius.Normal,
         borderTopRightRadius:
           id === tabs.currentId ? CapUIRadius.Accordion : CapUIRadius.Normal,
+        borderBottomLeftRadius: currentTabIsEmpty ? CapUIRadius.Accordion : 0,
+        borderBottomRightRadius: currentTabIsEmpty ? CapUIRadius.Accordion : 0,
         ...labelSx,
       }}
       className="tab__button"

--- a/src/components/Tabs/panel/TabsPanel.tsx
+++ b/src/components/Tabs/panel/TabsPanel.tsx
@@ -9,7 +9,13 @@ export interface TabsPanelprops extends BoxProps {}
 const TabsPanel: React.FC<TabsPanelprops> = ({ children, ...props }) => {
   const { tabs } = useTabs()
 
-  return (
+  return !children ? (
+    <BaseTabPanel
+      {...tabs}
+      tabIndex={undefined}
+      style={{ display: 'none' }}
+    ></BaseTabPanel>
+  ) : (
     <BaseTabPanel as={Box} p={6} {...tabs} tabIndex={undefined} {...props}>
       {children}
     </BaseTabPanel>

--- a/src/components/Tabs/panel/TabsPanel.tsx
+++ b/src/components/Tabs/panel/TabsPanel.tsx
@@ -9,14 +9,15 @@ export interface TabsPanelprops extends BoxProps {}
 const TabsPanel: React.FC<TabsPanelprops> = ({ children, ...props }) => {
   const { tabs } = useTabs()
 
-  return !children ? (
+  return (
     <BaseTabPanel
+      as={Box}
+      p={6}
       {...tabs}
       tabIndex={undefined}
-      style={{ display: 'none' }}
-    ></BaseTabPanel>
-  ) : (
-    <BaseTabPanel as={Box} p={6} {...tabs} tabIndex={undefined} {...props}>
+      {...props}
+      style={!children ? { display: 'none' } : undefined}
+    >
       {children}
     </BaseTabPanel>
   )


### PR DESCRIPTION
#### :tophat: What? Why?
Quand le contenu du TabPanel est vide, ça rend bizarre.
On veut retirer le bloc s'il est vide, et arrondir les angles du TabButton en conséquence.

#### :pushpin: Related Issues
Cf les irritants UI notifiés par Sylvain dans les commentaires de cette issue : https://github.com/cap-collectif/platform/issues/17262

#### :clipboard: Technical Specification
- [x] targeter les tabs qui n'ont pas de  contenu et renvoyer un tabPanel avec un `display: none`

#### :art: Chromatic links
<!--
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=<PR number>)
[Storybook](https://<branch>--60ca00d41db7ba003be931d8.chromatic.com) 
-->

#### :camera_flash: Screenshots
<img width="935" alt="Screenshot 2024-08-14 at 16 07 12" src="https://github.com/user-attachments/assets/32b740bb-e1f6-40d8-997e-9735ac7315e5">
<img width="928" alt="Screenshot 2024-08-14 at 16 07 28" src="https://github.com/user-attachments/assets/5bf3b71a-9b3e-4747-b4ff-4ec267e98ef8">
