### PR TITLE
fix(accessibility/modal): aria-labelledby not applied properly in modal

### DIFF
--- a/src/components/modal/Modal.stories.tsx
+++ b/src/components/modal/Modal.stories.tsx
@@ -39,7 +39,7 @@ export default meta
 export const Default: Story<ModalProps> = args => (
   <Modal
     {...args}
-    ariaLabelledBy="modal-title"
+    ariaLabelledby="modal-title"
     onOpen={() => {
       console.log('OPENED')
     }}

--- a/src/components/modal/Modal.stories.tsx
+++ b/src/components/modal/Modal.stories.tsx
@@ -39,6 +39,7 @@ export default meta
 export const Default: Story<ModalProps> = args => (
   <Modal
     {...args}
+    ariaLabelledBy="modal-title"
     onOpen={() => {
       console.log('OPENED')
     }}
@@ -49,7 +50,7 @@ export const Default: Story<ModalProps> = args => (
     {({ hide }) => (
       <>
         <Modal.Header closeIconLabel="Fermer">
-          <Heading>Title</Heading>
+          <Heading id="modal-title">Title</Heading>
         </Modal.Header>
         <Modal.Body>Content</Modal.Body>
         <Modal.Footer

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -30,6 +30,7 @@ export interface ModalProps extends FlexProps {
   readonly show?: boolean
   readonly children: RenderProps | React.ReactNode
   readonly ariaLabel: string
+  readonly ariaLabelledBy?: string
   readonly onOpen?: () => void
   readonly onClose?: () => void
   readonly baseId?: string
@@ -119,6 +120,7 @@ export const Modal: React.FC<ModalProps> & SubComponents = ({
   children,
   disclosure,
   ariaLabel,
+  ariaLabelledBy,
   onOpen,
   onClose,
   show,
@@ -193,6 +195,7 @@ export const Modal: React.FC<ModalProps> & SubComponents = ({
 
       <Dialog
         aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
         {...dialog}
         hideOnClickOutside={hideOnClickOutside}
         hideOnEsc={hideOnEsc}

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -30,7 +30,7 @@ export interface ModalProps extends FlexProps {
   readonly show?: boolean
   readonly children: RenderProps | React.ReactNode
   readonly ariaLabel: string
-  readonly ariaLabelledBy?: string
+  readonly ariaLabelledby?: string
   readonly onOpen?: () => void
   readonly onClose?: () => void
   readonly baseId?: string
@@ -120,7 +120,7 @@ export const Modal: React.FC<ModalProps> & SubComponents = ({
   children,
   disclosure,
   ariaLabel,
-  ariaLabelledBy,
+  ariaLabelledby,
   onOpen,
   onClose,
   show,
@@ -195,7 +195,7 @@ export const Modal: React.FC<ModalProps> & SubComponents = ({
 
       <Dialog
         aria-label={ariaLabel}
-        aria-labelledby={ariaLabelledBy}
+        aria-labelledby={ariaLabelledby}
         {...dialog}
         hideOnClickOutside={hideOnClickOutside}
         hideOnEsc={hideOnEsc}


### PR DESCRIPTION
#### :tophat: What? Why?
La propriété aria-labelledby ne fonctionnait pas correctement et se retrouvait passée au child de la modale au lieu du parent qui contient le `role="dialog"` et le `aria-modal="true"`

#### :pushpin: Related Issues
Cf Prio 5 dans ce ticket : https://github.com/cap-collectif/platform/issues/17279

#### :clipboard: Technical Specification
- [x] Ajout de la prop ariaLabelledby aux props et dans le composant <Dialog>
- [x] Ajout d'un exemple dans la story

#### :art: Chromatic links
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=458)
[Storybook](https://fix-aria-labelledby-drilling--60ca00d41db7ba003be931d8.chromatic.com) 


#### :camera_flash: Screenshots
<img width="348" alt="Screenshot 2024-09-18 at 14 14 13" src="https://github.com/user-attachments/assets/3e456204-c30d-4eb7-9973-ea24a0613178">
