### PR TITLE
fix: remove circular dependency on modal component

### DIFF
--- a/src/components/modal/header/ModalHeader.tsx
+++ b/src/components/modal/header/ModalHeader.tsx
@@ -8,6 +8,7 @@ import { Flex, FlexProps } from '../../layout'
 import { headingStyles } from '../../typography'
 import { useModal } from '../Modal.context'
 import ModalHeaderLabel from '../headerLabel/ModalHeaderLabel'
+import { MODAL_TITLE_ARIA_DESCRIBED_BY } from '../shared'
 
 type SubComponents = {
   Label: typeof ModalHeaderLabel
@@ -16,8 +17,6 @@ type SubComponents = {
 export type ModalHeaderProps = FlexProps & {
   readonly closeIconLabel?: string
 }
-
-export const MODAL_TITLE_ARIA_DESCRIBED_BY = 'modal-title'
 
 const ModalHeader: React.FC<ModalHeaderProps> & SubComponents = ({
   children,

--- a/src/components/modal/headerLabel/ModalHeaderLabel.tsx
+++ b/src/components/modal/headerLabel/ModalHeaderLabel.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 
 import { CapUIFontWeight } from '../../../styles'
 import { headingStyles, Text, TextProps } from '../../typography'
-import { MODAL_TITLE_ARIA_DESCRIBED_BY } from '../header/ModalHeader'
+import { MODAL_TITLE_ARIA_DESCRIBED_BY } from '../shared'
 
 type ModalHeaderLabelProps = TextProps & {
   children: React.ReactNode

--- a/src/components/modal/shared.ts
+++ b/src/components/modal/shared.ts
@@ -1,0 +1,1 @@
+export const MODAL_TITLE_ARIA_DESCRIBED_BY = 'modal-title'


### PR DESCRIPTION
#### :tophat: What? Why?
On a un warning sur des dépendances circulaires dans le composant Modal.
Cette PR corrige le souci.
Pas besoin de faire une release, ça sera embarqué dans la prochaine

#### :pushpin: Related Issues
Pas d'issue créée, juste ce warning au moment du `yarn`
```
⠧ Building modules
Circular dependency: src/components/modal/header/ModalHeader.tsx -> src/components/modal/headerLabel/ModalHeaderLabel.tsx -> src/components/modal/header/ModalHeader.tsx
Circular dependency: src/components/modal/header/ModalHeader.tsx -> src/components/modal/headerLabel/ModalHeaderLabel.tsx -> src/components/modal/header/ModalHeader.tsx
Circular dependency: src/components/modal/header/ModalHeader.tsx -> src/components/modal/hea
✓ Building modules 2.9 mins
✨  Done in 175.52s.
````

#### :clipboard: Technical Specification
- [x] Déplacer la variable partagée dans un dossier shared et màj tous les imports

#### :art: Chromatic links
<!--
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=<PR number>)
[Storybook](https://<branch>--60ca00d41db7ba003be931d8.chromatic.com) 
-->

#### :camera_flash: Screenshots
<!-- Screenshots if appropriate -->