### PR TITLE
fix: thumbnail persistence

### DIFF
--- a/src/components/form/uploader/Uploader.tsx
+++ b/src/components/form/uploader/Uploader.tsx
@@ -88,7 +88,8 @@ const Uploader: React.FC<UploaderProps> = ({
   const { colors } = useTheme()
 
   const [thumb, setThumb] = React.useState<string | null>(
-    !multiple && value && !Array.isArray(value) ? value.url : null,
+    // @ts-ignore > we need path property for upload of files without the url prop (e.g.: csv files)
+    !multiple && value && !Array.isArray(value) ? (value?.url || value?.path) : null,
   )
   const [loading, setLoading] = React.useState(false)
 

--- a/src/components/form/uploader/Uploader.tsx
+++ b/src/components/form/uploader/Uploader.tsx
@@ -89,10 +89,11 @@ const Uploader: React.FC<UploaderProps> = ({
   const { colors } = useTheme()
 
   const [thumb, setThumb] = React.useState<string | null>(
-    !multiple && value && !Array.isArray(value) 
-    ? (value.url || (value.path ?? null))
-    : null,
+    !multiple && value && !Array.isArray(value)
+    ? value.url || value.path || null
+    : null
   )
+  
   const [loading, setLoading] = React.useState(false)
 
   const isImageUploader =

--- a/src/components/form/uploader/Uploader.tsx
+++ b/src/components/form/uploader/Uploader.tsx
@@ -56,7 +56,7 @@ export interface UploaderProps
   readonly size?: UPLOADER_SIZE
   readonly value?: FileInfo | Array<FileInfo>
   readonly circle?: boolean
-  readonly format?: 'image/*' | 'audio/*' | 'video/*' | string | string[] // https://react-dropzone.js.org/#section-accepting-specific-file-types
+  readonly format?: 'image/*' | 'audio/*' | 'video/*' | string | string[]
   readonly minResolution?: Size
   readonly multiple?: boolean
   readonly showThumbnail?: boolean
@@ -90,8 +90,8 @@ const Uploader: React.FC<UploaderProps> = ({
 
   const [thumb, setThumb] = React.useState<string | null>(
     !multiple && value && !Array.isArray(value)
-    ? value.url || value.path || null
-    : null
+      ? value.url || value.path || null
+      : null,
   )
 
   const [loading, setLoading] = React.useState(false)

--- a/src/components/form/uploader/Uploader.tsx
+++ b/src/components/form/uploader/Uploader.tsx
@@ -93,8 +93,7 @@ const Uploader: React.FC<UploaderProps> = ({
     ? value.url || value.path || null
     : null
   )
-  
-  console.log("Hello darkness, my old friend", value)
+
   const [loading, setLoading] = React.useState(false)
 
   const isImageUploader =
@@ -262,7 +261,7 @@ const Uploader: React.FC<UploaderProps> = ({
                 color="gray.500"
               />
               <Text fontSize={3} color="gray.500">
-                {acceptedFiles.length > 0 && acceptedFiles[0].name}
+                {acceptedFiles.length > 0 && (acceptedFiles[0].name || thumb)}
               </Text>
             </FileThumbnail>
 

--- a/src/components/form/uploader/Uploader.tsx
+++ b/src/components/form/uploader/Uploader.tsx
@@ -94,6 +94,7 @@ const Uploader: React.FC<UploaderProps> = ({
     : null
   )
   
+  console.log("Hello darkness, my old friend", value)
   const [loading, setLoading] = React.useState(false)
 
   const isImageUploader =

--- a/src/components/form/uploader/Uploader.tsx
+++ b/src/components/form/uploader/Uploader.tsx
@@ -38,6 +38,7 @@ export type FileInfo = {
   size: string
   url: string
   type: string
+  path?: string
 }
 
 export type WordingType = {
@@ -88,8 +89,9 @@ const Uploader: React.FC<UploaderProps> = ({
   const { colors } = useTheme()
 
   const [thumb, setThumb] = React.useState<string | null>(
-    // @ts-ignore > we need path property for upload of files without the url prop (e.g.: csv files)
-    !multiple && value && !Array.isArray(value) ? (value?.url || value?.path) : null,
+    !multiple && value && !Array.isArray(value) 
+    ? (value.url || (value.path ?? null))
+    : null,
   )
   const [loading, setLoading] = React.useState(false)
 


### PR DESCRIPTION
Quand on upload un fichier qui n'a pas de propriété url et qu'on change d'onglet (dans une modale par exemple) puis qu'on revient sur l'uploader, la miniature n'est pas conservée puisque la miniature est set seulement si on a une propriété url.

#### :tophat: What? Why?
Prendre la valeur de value.path OU value.url

#### :pushpin: Related Issues
Pas d'issue créée, c'est un souci que j'ai vu en travaillant sur la refonte de la page invitations.
https://github.com/cap-collectif/platform/pull/17251

#### :clipboard: Technical Specification
- [x] ajouter une propriété `path`

#### :art: Chromatic links
<!--
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=<PR number>)
[Storybook](https://<branch>--60ca00d41db7ba003be931d8.chromatic.com) 
-->

#### :camera_flash: Screenshots
<!-- Screenshots if appropriate -->