### PR TITLE
fix: remove tab button padding

### DIFF
--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -40,7 +40,7 @@ export const Default: Story<TabsProps> = args => {
         <Tabs.ButtonList ariaLabel="Tabs example">
           <Tabs.Button id="tab1">Tab1</Tabs.Button>
           <Tabs.Button id="tab2">Tab2</Tabs.Button>
-          <Tabs.Button id="tab3">Tab3</Tabs.Button>
+          <Tabs.Button id="tab3">Tab3 with a rather long - very very long - name</Tabs.Button>
         </Tabs.ButtonList>
         <Tabs.PanelList>
           <Tabs.Panel>

--- a/src/components/Tabs/button/TabsButton.tsx
+++ b/src/components/Tabs/button/TabsButton.tsx
@@ -45,6 +45,7 @@ const TabsButton: React.FC<TabsButtonProps> = ({
         cursor: 'pointer',
         transition: 'box-shadow 0.2s, opacity 0.2s',
         width: '100%',
+        px: 4,
         py: 2,
         justifyContent: 'center !important',
         backgroundColor: id === tabs.currentId ? '#F7F7F8' : 'transparent',

--- a/src/components/Tabs/button/TabsButton.tsx
+++ b/src/components/Tabs/button/TabsButton.tsx
@@ -45,7 +45,6 @@ const TabsButton: React.FC<TabsButtonProps> = ({
         cursor: 'pointer',
         transition: 'box-shadow 0.2s, opacity 0.2s',
         width: '100%',
-        px: '100px',
         py: 2,
         justifyContent: 'center !important',
         backgroundColor: id === tabs.currentId ? '#F7F7F8' : 'transparent',


### PR DESCRIPTION
#### :tophat: What? Why?
On a un affichage buggy dès lors qu'on a plusieurs TabButtons ou que la largeur de fenêtre est trop petite.


#### :pushpin: Related Issues
Pas créé d'issue mais on en a parlé plusieurs fois et c'est un méga quick fix.

#### :clipboard: Technical Specification
- [x] diminuer le padding qui élargit le button

#### :art: Chromatic links

[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=470)
[Storybook](https://fix-tabs-padding--60ca00d41db7ba003be931d8.chromatic.com) 


#### :camera_flash: Screenshots
AVANT :
![image](https://github.com/user-attachments/assets/0ea095b9-71bf-4956-93e1-ea430aab2fc1)

APRES : 
![image](https://github.com/user-attachments/assets/0b928b18-ed76-400d-8eb1-845e660d9108)
