### PR TITLE
feat: add sideContent to TabBar

### DIFF
--- a/src/components/tabBar/TabBar.stories.tsx
+++ b/src/components/tabBar/TabBar.stories.tsx
@@ -1,7 +1,10 @@
 import { Meta, Story } from '@storybook/react'
 import React from 'react'
 
+import { Button } from '../button'
+import { Icon, CapUIIcon } from '../icon'
 import { Flex } from '../layout'
+import { Link } from '../link'
 import TabBar, { TabBarProps } from './TabBar'
 import TabPane from './pane/TabPane'
 
@@ -37,3 +40,42 @@ const Template: Story<TabBarProps> = () => {
 }
 
 export const Default = Template.bind({})
+
+export const WithLink: Story<TabBarProps> = () => {
+  return (
+    <TabBar
+      defaultTab="agui"
+      sideContent={
+        <>
+          <Link
+            href={'https://www.cap-collectif.com/'}
+            display={'flex'}
+            color="primary.600"
+            mr={0}
+            ml={'auto'}
+            target="_blank"
+          >
+            <Icon name={CapUIIcon.Preview} />
+            Cap Collectif
+          </Link>
+          <Button>I love cats</Button>
+        </>
+      }
+    >
+      <TabPane id="agui" title="agui">
+        <Flex m={4}>Lili présidente</Flex>
+      </TabPane>
+      <TabPane id="myriam" title="myriam">
+        <Flex m={4}>Cheffe pâtissière végane</Flex>
+      </TabPane>
+      <TabPane id="alex" title="alex" count={666}>
+        <Flex m={4}>Pianiste de l'équipe</Flex>
+      </TabPane>
+      <TabPane
+        id="capco"
+        title="Onglet avec redirection"
+        href={'https://www.cap-collectif.com/'}
+      />
+    </TabBar>
+  )
+}

--- a/src/components/tabBar/TabBar.tsx
+++ b/src/components/tabBar/TabBar.tsx
@@ -48,7 +48,7 @@ const TabBar: React.FC<TabBarProps> & SubComponents = ({
         paddingX={6}
         {...props}
       >
-        <Flex gap={6}>
+        <Flex gap={6} height={'inherit'}>
           {childrenToArray.map(child => (
             <TabHeader
               key={child.props.id}

--- a/src/components/tabBar/TabBar.tsx
+++ b/src/components/tabBar/TabBar.tsx
@@ -11,6 +11,7 @@ export type TabBarProps = BoxProps & {
   children: React.ReactElement[] | React.ReactElement
   defaultTab: string
   onChange?: (tabId: string) => void
+  sideContent?: React.ReactNode
 }
 
 type SubComponents = {
@@ -21,6 +22,7 @@ const TabBar: React.FC<TabBarProps> & SubComponents = ({
   children,
   defaultTab,
   onChange,
+  sideContent,
   ...props
 }) => {
   const [currentTab, setCurrentTab] = React.useState<string>(defaultTab)
@@ -36,8 +38,7 @@ const TabBar: React.FC<TabBarProps> & SubComponents = ({
       <Flex
         as={'ul'}
         backgroundColor="#FFF"
-        display="inline-flex"
-        justifyContent="flex-start"
+        justifyContent="space-between"
         align="center"
         height={pxToRem(48)}
         minHeight={pxToRem(48)}
@@ -47,23 +48,31 @@ const TabBar: React.FC<TabBarProps> & SubComponents = ({
         paddingX={6}
         {...props}
       >
-        {childrenToArray.map(child => (
-          <TabHeader
-            key={child.props.id}
-            href={child.props.href}
-            title={child.props.title}
-            id={child.props.id}
-            count={child.props.count}
-            onClick={() => {
-              if (currentTab !== child.props.id) {
-                setCurrentTab(child.props.id)
-              }
-            }}
-            isActive={currentTab === child.props.id}
-          >
-            {child.props}
-          </TabHeader>
-        ))}
+        <Flex gap={6}>
+          {childrenToArray.map(child => (
+            <TabHeader
+              key={child.props.id}
+              href={child.props.href}
+              title={child.props.title}
+              id={child.props.id}
+              count={child.props.count}
+              onClick={() => {
+                if (currentTab !== child.props.id) {
+                  setCurrentTab(child.props.id)
+                }
+              }}
+              isActive={currentTab === child.props.id}
+            >
+              {child.props}
+            </TabHeader>
+          ))}
+        </Flex>
+
+        {sideContent && (
+          <Flex alignItems={'center'} gap={4}>
+            {sideContent}
+          </Flex>
+        )}
       </Flex>
       {childrenToArray?.length ? (
         <Flex>


### PR DESCRIPTION
#### :tophat: What? Why?
Ajouter un élément "sideContent" au composant TabBar.

Dans de nouvelles maquettes, le composant contient un élément supplémentaire sur le côté.

#### :pushpin: Related Issues
https://github.com/cap-collectif/platform/issues/17423

#### :clipboard: Technical Specification
- [x] ajouter la prop sideContent
- [x] ajouter une story pour documenter cette feature

#### :art: Chromatic links
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=476)
[Storybook](https://add-sidecontent-to-tabbar--60ca00d41db7ba003be931d8.chromatic.com) 

#### :camera_flash: Screenshots
<!-- Screenshots if appropriate -->