### PR TITLE
feat(TabBar): add keyboard navigation

### DIFF
--- a/src/components/tabBar/TabBar.tsx
+++ b/src/components/tabBar/TabBar.tsx
@@ -61,6 +61,11 @@ const TabBar: React.FC<TabBarProps> & SubComponents = ({
                   setCurrentTab(child.props.id)
                 }
               }}
+              onKeyDown={event => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  setCurrentTab(child.props.id)
+                }
+              }}
               isActive={currentTab === child.props.id}
             >
               {child.props}

--- a/src/components/tabBar/TabHeader.tsx
+++ b/src/components/tabBar/TabHeader.tsx
@@ -8,7 +8,7 @@ export type TabHeaderProps = {
   id: string
   href?: string
   onClick: () => void
-  onKeyDown: (event: any) => void | undefined
+  onKeyDown: (event: React.KeyboardEvent) => void | undefined
   isActive: boolean
   count?: number
 }

--- a/src/components/tabBar/TabHeader.tsx
+++ b/src/components/tabBar/TabHeader.tsx
@@ -50,6 +50,7 @@ const TabHeader: React.FC<TabHeaderProps> = ({
         }
       }}
       onClick={isLink ? undefined : onClick}
+      tabIndex={0}
       {...props}
     >
       {title}

--- a/src/components/tabBar/TabHeader.tsx
+++ b/src/components/tabBar/TabHeader.tsx
@@ -8,6 +8,7 @@ export type TabHeaderProps = {
   id: string
   href?: string
   onClick: () => void
+  onKeyDown: (event: any) => void | undefined
   isActive: boolean
   count?: number
 }
@@ -16,6 +17,7 @@ const TabHeader: React.FC<TabHeaderProps> = ({
   title,
   href,
   onClick,
+  onKeyDown,
   isActive,
   count,
   ...props
@@ -47,9 +49,10 @@ const TabHeader: React.FC<TabHeaderProps> = ({
         '&:hover .tabHeaderCount': {
           color: 'primary.500',
           backgroundColor: 'primary.150',
-        }
+        },
       }}
       onClick={isLink ? undefined : onClick}
+      onKeyDown={isLink ? undefined : onKeyDown}
       tabIndex={0}
       {...props}
     >
@@ -57,14 +60,14 @@ const TabHeader: React.FC<TabHeaderProps> = ({
       {count !== undefined && (
         <Box
           as="span"
-          className='tabHeaderCount'
+          className="tabHeaderCount"
           bg={isActive ? 'primary.150' : 'neutral-gray.150'}
           color={isActive ? 'primary.500' : 'neutral-gray.500'}
           sx={{
             fontWeight: 600,
             height: 4,
-            px:1,
-            py:0,
+            px: 1,
+            py: 0,
             borderRadius: CapUIRadius.Tags,
             marginLeft: 1,
             fontSize: 2,

--- a/src/components/tabBar/pane/TabPane.tsx
+++ b/src/components/tabBar/pane/TabPane.tsx
@@ -3,7 +3,10 @@ import React from 'react'
 import { Box, BoxProps } from '../../box'
 import { TabHeaderProps } from '../TabHeader'
 
-export type TabPaneProps = Omit<TabHeaderProps, 'onClick' | 'isActive'> & {
+export type TabPaneProps = Omit<
+  TabHeaderProps,
+  'onClick' | 'onKeyDown' | 'isActive'
+> & {
   children?: React.ReactNode
 }
 


### PR DESCRIPTION
#### :tophat: What? Why?
La tabbar n'était pas tabbable, donc pas possible de naviguer au clavier.

#### :pushpin: Related Issues
En lien avec la refonte du BO - page Utilisateur·ices : https://github.com/cap-collectif/platform/issues/17426

#### :clipboard: Technical Specification
- [x] Ajout du tabIndex
- [x] Ajout du onKeyDown handler

#### :art: Chromatic links

[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=479)
[Storybook](https://add-tabbable-to-tabbar--60ca00d41db7ba003be931d8.chromatic.com) 

#### :camera_flash: Screenshots
<!-- Screenshots if appropriate -->