### PR TITLE
fix: toast width

### DIFF
--- a/src/components/toast/Toast.stories.tsx
+++ b/src/components/toast/Toast.stories.tsx
@@ -117,6 +117,24 @@ export const Default: Story<ToastProps> = args => (
       variant="primary"
       variantSize="medium"
       onClick={() => {
+        toast({
+          ...args,
+          variant: 'success',
+          content: `Toast with an extraordinarily long label that should help see how such a
+      case would be rendered if someone had the craziest idea of making it an
+      actual real-life case, like who would do this anyway?`,
+
+          onClose: () =>
+            console.log("Un log qui s'affiche à la fermeture du toast !"),
+        })
+      }}
+    >
+      Toast with very long content
+    </Button>
+    <Button
+      variant="primary"
+      variantSize="medium"
+      onClick={() => {
         clearToasts()
       }}
     >

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -49,6 +49,7 @@ const ToastInner = styled(motion(Box)).attrs({
   pointer-events: all;
   position: relative;
   width: fit-content;
+  max-width: 500px;
   margin-left: auto;
   margin-right: auto;
 


### PR DESCRIPTION
#### :tophat: What? Why?
Lorsqu'on a un toast avec un contenu très long, la largeur n'a pas de maximum.
J'ai corrigé le souci et ajouté une story pour refléter ce cas.

#### :pushpin: Related Issues
https://github.com/cap-collectif/platform/issues/17699

#### :clipboard: Technical Specification
- [x] ajouter une maxWidth
- [x] ajouter une story

#### :art: Chromatic links
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=480)
[Storybook](https://17699-fix-toast-width--60ca00d41db7ba003be931d8.chromatic.com) 

#### :camera_flash: Screenshots
AVANT :
<img width="836" alt="Screenshot 2025-01-08 at 10 07 15" src="https://github.com/user-attachments/assets/f898da27-8203-4ffb-8021-b79da2b77e80" />


APRES :
<img width="818" alt="Screenshot 2025-01-08 at 10 05 36" src="https://github.com/user-attachments/assets/35c126f7-96fd-4b89-87db-6b8cd4b00d64" />
