### PR TITLE
fix: 0 on Table that was displaying -0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,11 +4,6 @@
 #### :pushpin: Related Issues
 <!-- What existing **issue(s)** does the pull request solve? -->
 
-#### :clipboard: Technical Specification
-<!-- Describe how you plan to solve the problem
-- [x] Subtask 1
-- [ ] Subtask 2
--->
 
 #### :art: Chromatic links
 <!--

--- a/src/components/table/Table.stories.tsx
+++ b/src/components/table/Table.stories.tsx
@@ -165,7 +165,7 @@ const Template: Story<TableProps> = args => (
         </Table.Td>
         <Table.Td>CEO</Table.Td>
         <Table.Td>Russia</Table.Td>
-        <Table.Td isNumeric>789123456</Table.Td>
+        <Table.Td isNumeric>{Number(0)}</Table.Td>
         <Table.Td>10/01/2030</Table.Td>
         <Table.Td>
           Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusamus ad

--- a/src/components/table/td/Td.tsx
+++ b/src/components/table/td/Td.tsx
@@ -29,7 +29,7 @@ export const Td: React.FC<TdProps> = ({
   ...props
 }) => {
   const { isLoading } = useTable()
-  const isEmpty: boolean = !children && !isLoading
+  const isEmpty: boolean = !children && children !== 0 && !isLoading
 
   return (
     <Box


### PR DESCRIPTION
#### :tophat: What? Why?
The issue was that if the value vas 0 (of type number), the cell was considered empty because children was falsy. Thus returning a dash (placeholder for empty cells)
J'ai ajouté un 0 dans la story Table Default pour qu'on spot plus facilement si régression.

#### :pushpin: Related Issues
https://github.com/cap-collectif/platform/issues/17750

#### :art: Chromatic links
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=484)
[Storybook](https://fix-minus-zero-table--60ca00d41db7ba003be931d8.chromatic.com) 

#### :camera_flash: Screenshots
<!-- Screenshots if appropriate -->