### PR TITLE
fix: finally adapt uploader sizes to match specs

### DIFF
--- a/src/components/form/uploader/Uploader.style.tsx
+++ b/src/components/form/uploader/Uploader.style.tsx
@@ -24,7 +24,7 @@ export const Container = styled(Flex)<{
       case UPLOADER_SIZE.MD:
       case UPLOADER_SIZE.SM:
       default:
-        return '184px'      
+        return '184px'
     }
   }};
   max-width: ${props => {
@@ -34,7 +34,7 @@ export const Container = styled(Flex)<{
         return '488px'
       case UPLOADER_SIZE.SM:
       default:
-        return '184px'      
+        return '184px'
     }
   }};
   width: 100%;
@@ -115,7 +115,7 @@ export const UploaderContainer = styled(Flex)<{
       case UPLOADER_SIZE.MD:
       case UPLOADER_SIZE.SM:
       default:
-        return '184px'      
+        return '184px'
     }
   }};
   max-width: ${props => {
@@ -125,7 +125,7 @@ export const UploaderContainer = styled(Flex)<{
         return '488px'
       case UPLOADER_SIZE.SM:
       default:
-        return '184px'      
+        return '184px'
     }
   }};
   width: 100%;


### PR DESCRIPTION
#### :tophat: What? Why?
On match ce qui est écrit ici : https://www.notion.so/Uploader-f19c0412a94b4028990ce8508fa1e52d
J'ai fais des changements sur la taille, faudra peut être adapter sur platform, je regarderai ça dans la foulée 
#### :pushpin: Related Issues
<!-- What existing **issue(s)** does the pull request solve? -->


#### :art: Chromatic links
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=485)
[Storybook](https://17667-uploader--60ca00d41db7ba003be931d8.chromatic.com) 

#### :camera_flash: Screenshots
<!-- Screenshots if appropriate -->