### PR TITLE
fix: tabbar design

### DIFF
--- a/src/components/tabBar/TabBar.tsx
+++ b/src/components/tabBar/TabBar.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 
-import { CapUIShadow } from '../../styles'
 import { pxToRem } from '../../styles/modules/mixins'
 import { BoxProps } from '../box'
 import { Flex } from '../layout'
@@ -43,7 +42,9 @@ const TabBar: React.FC<TabBarProps> & SubComponents = ({
         height={pxToRem(48)}
         minHeight={pxToRem(48)}
         width="100%"
-        boxShadow={CapUIShadow.Small}
+        borderBottomStyle={'solid'}
+        borderBottomWidth={1}
+        borderBottomColor={'gray.150'}
         gap={6}
         paddingX={6}
         {...props}

--- a/src/components/tabBar/TabHeader.tsx
+++ b/src/components/tabBar/TabHeader.tsx
@@ -44,7 +44,6 @@ const TabHeader: React.FC<TabHeaderProps> = ({
         borderBottom: '2px solid transparent',
         '&:hover': {
           color: 'primary.500',
-          borderBottomColor: 'primary.500',
         },
         '&:hover .tabHeaderCount': {
           color: 'primary.500',


### PR DESCRIPTION
#### :tophat: What? Why?
Sylvain a demandé une mise à jour du composant TabBar pour correspondre au design :  
- on remplace le boxShadow par une border-bottom
- on retire le soulignage en bleu d'un onglet hovered (le soulignage bleu est uniquement sur l'onglet actif)

#### :pushpin: Related Issues
Lié à la refonte de la page sonata des Groupes d'utilisateur·ices https://github.com/cap-collectif/platform/issues/17424#issuecomment-2642584042

#### :clipboard: Technical Specification
- [x] retrait du box-shadow
- [x] retrait de la barre bleue au hover

#### :art: Chromatic links
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=486)
[Storybook](https://remove-tabbar-box-shadow--60ca00d41db7ba003be931d8.chromatic.com) 

#### :camera_flash: Screenshots
Onglet actif : Agui
Onglet hovered : Alex

Avant : 
<img width="431" alt="Screenshot 2025-02-07 at 17 20 29" src="https://github.com/user-attachments/assets/3aa99b6e-16c1-46e0-9995-622a95b11291" />

Après : 
<img width="533" alt="Screenshot 2025-02-07 at 17 22 35" src="https://github.com/user-attachments/assets/e6b33160-dc3d-47eb-853d-2b3362cd907d" />


