### PR TITLE
feat: add fullWidth prop to `Uploader`

### DIFF
--- a/src/components/form/uploader/Uploader.stories.tsx
+++ b/src/components/form/uploader/Uploader.stories.tsx
@@ -11,9 +11,11 @@ import { CapUIFontWeight } from '../../../styles'
 import { btomg, mgtob } from '../../../utils/fileSizeConvert'
 import fileType from '../../../utils/fileType'
 import { Box } from '../../box/Box'
+import { Button } from '../../button'
 import { InfoMessage } from '../../infoMessage/InfoMessage'
 import { Flex } from '../../layout'
-import { Text } from '../../typography'
+import { ModalProps, Modal, CapUIModalSize } from '../../modal'
+import { Heading, Text } from '../../typography'
 import { FormControl } from '../formControl'
 import { FormErrorMessage } from '../formErrorMessage'
 import { FormGuideline } from '../formGuideline'
@@ -1326,4 +1328,82 @@ UniqueWithWarning.args = {
     url: lowQualityThumbnail,
     type: 'image/jpeg',
   },
+}
+
+export const FullWidth: Story<ModalProps> = args => (
+  <Modal {...args} ariaLabelledby="modal-title" size={CapUIModalSize.Xl}>
+    {({ hide }) => (
+      <>
+        <Modal.Header closeIconLabel="Fermer">
+          <Heading id="modal-title">
+            With & without isFullWidth property
+          </Heading>
+        </Modal.Header>
+        <Modal.Body width={'100%'} display={'flex'} gap={4}>
+          <Flex direction={'column'}>
+            <FormGuideline>With the `isFullWidth` property</FormGuideline>
+            <Uploader
+              isFullWidth
+              className={'cap-uploader'}
+              format={'image/*'}
+              onDrop={(
+                acceptedFiles: File[],
+                fileRejections: FileRejection[],
+                event: DropEvent,
+              ) => {
+                console.log(acceptedFiles, fileRejections, event)
+              }}
+              wording={{
+                uploaderPrompt: '',
+                uploaderLoadingPrompt: '',
+                fileDeleteLabel: '',
+              }}
+            />
+          </Flex>
+          <Flex direction={'column'}>
+            <FormGuideline>Without the `isFullWidth` property</FormGuideline>
+            <Uploader
+              className={'cap-uploader'}
+              format={'image/*'}
+              onDrop={(
+                acceptedFiles: File[],
+                fileRejections: FileRejection[],
+                event: DropEvent,
+              ) => {
+                console.log(acceptedFiles, fileRejections, event)
+              }}
+              wording={{
+                uploaderPrompt: '',
+                uploaderLoadingPrompt: '',
+                fileDeleteLabel: '',
+              }}
+            />
+          </Flex>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button
+            variant="secondary"
+            variantColor="primary"
+            variantSize="big"
+            onClick={hide}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            variantColor="primary"
+            variantSize="big"
+            onClick={hide}
+          >
+            Validate
+          </Button>
+        </Modal.Footer>
+      </>
+    )}
+  </Modal>
+)
+
+FullWidth.args = {
+  disclosure: <Button>Check display within modal</Button>,
+  size: CapUIModalSize.Md,
 }

--- a/src/components/form/uploader/Uploader.style.tsx
+++ b/src/components/form/uploader/Uploader.style.tsx
@@ -15,6 +15,7 @@ export const Container = styled(Flex)<{
   readonly circle?: boolean
   readonly drag: boolean
   readonly colors: Colors
+  readonly isFullWidth?: boolean
 }>`
   height: 184px;
   min-width: ${props => {
@@ -28,14 +29,18 @@ export const Container = styled(Flex)<{
     }
   }};
   max-width: ${props => {
-    switch (props.size) {
-      case UPLOADER_SIZE.LG:
-      case UPLOADER_SIZE.MD:
-        return '488px'
+    if (props.isFullWidth) {
+      return undefined
+    } else {
+      switch (props.size) {
+        case UPLOADER_SIZE.LG:
+        case UPLOADER_SIZE.MD:
+          return '488px'
       case UPLOADER_SIZE.SM:
-      default:
-        return '184px'
-    }
+        default:
+          return '184px'
+        }
+      }
   }};
   width: 100%;
   background-color: transparent;
@@ -102,6 +107,7 @@ export const Content = styled(Flex)`
 `
 export const UploaderContainer = styled(Flex)<{
   readonly size?: ResponsiveValue<UPLOADER_SIZE>
+  readonly isFullWidth?: boolean
 }>`
   flex-flow: column nowrap;
   justify-content: flex-start;
@@ -119,13 +125,17 @@ export const UploaderContainer = styled(Flex)<{
     }
   }};
   max-width: ${props => {
-    switch (props.size) {
-      case UPLOADER_SIZE.LG:
-      case UPLOADER_SIZE.MD:
-        return '488px'
-      case UPLOADER_SIZE.SM:
-      default:
-        return '184px'
+    if (props.isFullWidth) {
+      return undefined
+    } else {
+      switch (props.size) {
+        case UPLOADER_SIZE.LG:
+        case UPLOADER_SIZE.MD:
+          return '488px'
+        case UPLOADER_SIZE.SM:
+        default:
+          return '184px'
+      }
     }
   }};
   width: 100%;

--- a/src/components/form/uploader/Uploader.tsx
+++ b/src/components/form/uploader/Uploader.tsx
@@ -60,6 +60,7 @@ export interface UploaderProps
   readonly minResolution?: Size
   readonly multiple?: boolean
   readonly showThumbnail?: boolean
+  readonly isFullWidth?: boolean
   readonly onDrop: <T extends File>(
     acceptedFiles: T[],
     fileRejections: FileRejection[],
@@ -81,6 +82,7 @@ const Uploader: React.FC<UploaderProps> = ({
   onDrop: onExternalDrop,
   wording,
   minSize,
+  isFullWidth,
   className,
   onDropRejected,
   onRemove,
@@ -242,9 +244,14 @@ const Uploader: React.FC<UploaderProps> = ({
     }
   }
   return (
-    <UploaderContainer className={cn('cap-uploader', className)} size={size}>
+    <UploaderContainer
+      className={cn('cap-uploader', className)}
+      size={size}
+      isFullWidth={isFullWidth}
+    >
       <Container
         drag={isDragActive}
+        isFullWidth={isFullWidth}
         circle={circle}
         size={size}
         colors={colors}


### PR DESCRIPTION
#### :tophat: What? Why?
Suite à l'ajout des specs de taille des Uploader, on crée une régression visuelle notamment dans les modales, où on veut que l'Uploader prenne toute la largeur de la modale (sauf en cas de modale trop grande, comme la fullscreen)

#### :pushpin: Related Issues
Nécessaire suite à la màj de la version du DS dans le ticket de la refonte de la page Groupes d'utilisateur·ices.
Nécessaire également pour éviter une régression sur la page d'invitation des utilisateur·ices


#### :art: Chromatic links
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=488)
[Storybook](https://add-fullwidth-uploader--60ca00d41db7ba003be931d8.chromatic.com) 

#### :camera_flash: Screenshots
Story ajoutée pour visualiser la différence avec / sans `isFullWidth`
<img width="545" alt="Screenshot 2025-02-11 at 15 47 44" src="https://github.com/user-attachments/assets/e72fa6ac-53b7-48a1-964d-d7c592dd97f2" />
