### PR TITLE
fix: update btnquickaction bg color

### DIFF
--- a/src/utils/getThemeWithColorsToken.ts
+++ b/src/utils/getThemeWithColorsToken.ts
@@ -278,7 +278,7 @@ const actionColors = (theme: CapUITheme) => ({
   action: {
     primary: {
       background: {
-        default: theme.colors.transparent,
+        default: theme.colors.white,
         hover: theme.colors.primary.lighter,
       },
       icon: {
@@ -289,7 +289,7 @@ const actionColors = (theme: CapUITheme) => ({
     },
     danger: {
       background: {
-        default: theme.colors.transparent,
+        default: theme.colors.white,
         hover: theme.colors.danger.lighter,
       },
       icon: {
@@ -300,7 +300,7 @@ const actionColors = (theme: CapUITheme) => ({
     },
     hierarchy: {
       background: {
-        default: theme.colors.transparent,
+        default: theme.colors.gray.white,
         hover: theme.colors.gray.lighter,
       },
       icon: {

--- a/src/utils/getThemeWithColorsToken.ts
+++ b/src/utils/getThemeWithColorsToken.ts
@@ -300,7 +300,7 @@ const actionColors = (theme: CapUITheme) => ({
     },
     hierarchy: {
       background: {
-        default: theme.colors.gray.white,
+        default: theme.colors.white,
         hover: theme.colors.gray.lighter,
       },
       icon: {


### PR DESCRIPTION
#### :tophat: What? Why?
<!-- Describe your changes -->
Modification de la couleur de background du compo `ButtonQuickAction`, vu et validé avec Sylvain.
Nécessaire pour la màj du compo ButtonQuickAction dans platform à cause de l'impact sur les composants Carrousel / A la une.

#### :pushpin: Related Issues
<!-- What existing **issue(s)** does the pull request solve? -->
https://github.com/cap-collectif/platform/issues/18036

#### :art: Chromatic links
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=503)
[Storybook](https://add-background-to-btnquickaction--60ca00d41db7ba003be931d8.chromatic.com) 

#### :camera_flash: Screenshots
<!-- Screenshots if appropriate -->