### PR TITLE
6.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ To better understand the changelog, here are some legends we use:
 - 🛠 Refactor
 - 💄 Style
 
+## 6.0.2
+
+`2025-08-08`
+
+- 🆕 Make `Input` type `text` able to receive `onClickAction` icons [#535](https://github.com/cap-collectif/ui/pull/535)
+
 ## 6.0.1
 
 `2025-08-05`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.0.1",
+  "version": "6.0.2",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## 6.0.2

`2025-08-08`

- 🆕 Make `Input` type `text` able to receive `onClickAction` icons [#535](https://github.com/cap-collectif/ui/pull/535)
