### PR TITLE
fix(tag): move some css rules to a .style file

### DIFF
--- a/src/components/tag/label/TagLabel.style.ts
+++ b/src/components/tag/label/TagLabel.style.ts
@@ -1,0 +1,6 @@
+import { SystemStyleObject } from '@styled-system/css'
+
+export const tagLabelStyle = (): SystemStyleObject => ({
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+})

--- a/src/components/tag/label/TagLabel.tsx
+++ b/src/components/tag/label/TagLabel.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { CapUILineHeight } from '../../../styles'
 import { Box } from '../../box'
 import { TextProps } from '../../typography/Text'
+import { tagLabelStyle } from './TagLabel.style'
 
 export type TagLabelProps = TextProps
 
@@ -18,8 +19,7 @@ const TagLabel: React.FC<TagLabelProps> = ({
     lineHeight={CapUILineHeight.S}
     fontFamily="inherit"
     overflow="hidden"
-    whiteSpace="nowrap"
-    textOverflow="ellipsis"
+    sx={tagLabelStyle()}
     {...rest}
   >
     {children}


### PR DESCRIPTION
#### :tophat: What? Why?
<!-- Describe your changes -->
Quelques règles css sont appliquées sur le composant Box mais ne sont pas reconnues.
J'ai déplacé les règles dans un fichier .style pour les appliquer correctement au composant.

#### :pushpin: Related Issues
<!-- What existing **issue(s)** does the pull request solve? -->
https://github.com/cap-collectif/platform/issues/18041

#### :art: Chromatic links
[Chromatic PR](https://www.chromatic.com/pullrequest?appId=60ca00d41db7ba003be931d8&number=542)
[Storybook](https://fix-tag--60ca00d41db7ba003be931d8.chromatic.com) 

#### :camera_flash: Screenshots
<!-- Screenshots if appropriate -->